### PR TITLE
Feature: sync from all app windows

### DIFF
--- a/development/build-with-qmake.sh
+++ b/development/build-with-qmake.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 QT_DIR=${1}
 BUILD_TYPE=${2}
+CLEAN=${3}
 
 function error_exit {
     echo "***********error_exit***********"
@@ -24,21 +25,21 @@ if [ ! -f src/main.cpp ]; then
   exit 1
 fi
 
-
-
 if [ -z "${BUILD_TYPE}" ]; then
     BUILD_TYPE=debug
 fi
 BUILD_DIR=qmake-build-${BUILD_TYPE}
+
+if [ ! -z "${CLEAN}" ]; then
+  echo "Clean build: ${BUILD_DIR}"
+  if [ -d "${BUILD_DIR}" ]; then
+    rm -rf ${BUILD_DIR}
+  fi
+fi
+
 if [ ! -d "${BUILD_DIR}" ]; then
   mkdir ${BUILD_DIR}
 fi
-
-
-# maybe later add with "clean" parameter
-#if [ -d "${BUILD_DIR}" ]; then
-#  rm -rf ${BUILD_DIR}
-#fi
 
 VERSION="$(cat version.txt)-$(git rev-parse --short HEAD)"
 # for simplicity now create in both dirs
@@ -66,5 +67,5 @@ fi
 
 
 ${QMAKE_BINARY} CONFIG+=${BUILD_TYPE} PREFIX=appdir/usr || error_exit "qmake"
-make || error_exit "make"
+make -j8 || error_exit "make"
 make install || error_exit "make install"

--- a/src/gui/browserWidgets/editorbuttonbar.cpp
+++ b/src/gui/browserWidgets/editorbuttonbar.cpp
@@ -36,6 +36,7 @@ EditorButtonBar::EditorButtonBar(QWidget *parent) :
     // read state of the colors from init file
     getButtonbarColorState();
 
+    // Note window toolbar pop-up menu to pick what appears on toolbar
     contextMenu = new QMenu();
     undoVisible = contextMenu->addAction(tr("Undo"));
     redoVisible = contextMenu->addAction(tr("Redo"));
@@ -68,6 +69,7 @@ EditorButtonBar::EditorButtonBar(QWidget *parent) :
     insertTableButtonVisible = contextMenu->addAction(tr("Insert Table"));
     htmlEntitiesButtonVisible = contextMenu->addAction(tr("HTML Entities"));
     formatCodeButtonVisible = contextMenu->addAction(tr("Format Code Block"));
+    syncButtonVisible = contextMenu->addAction(tr("Sync"));
 
     undoVisible->setCheckable(true);
     redoVisible->setCheckable(true);
@@ -102,6 +104,7 @@ EditorButtonBar::EditorButtonBar(QWidget *parent) :
     htmlEntitiesButtonVisible->setCheckable(true);
     insertDatetimeVisible->setCheckable(true);
     formatCodeButtonVisible->setCheckable(true);
+    syncButtonVisible->setCheckable(true);
 
     connect(undoVisible, SIGNAL(triggered()), this, SLOT(toggleUndoButtonVisible()));
     connect(redoVisible, SIGNAL(triggered()), this, SLOT(toggleRedoButtonVisible()));
@@ -134,6 +137,7 @@ EditorButtonBar::EditorButtonBar(QWidget *parent) :
     connect(spellCheckButtonVisible, SIGNAL(triggered()), this, SLOT(toggleSpellCheckButtonVisible()));
     connect(htmlEntitiesButtonVisible, SIGNAL(triggered()), this, SLOT(toggleHtmlEntitiesButtonVisible()));
     connect(formatCodeButtonVisible, SIGNAL(triggered()), this, SLOT(toggleFormatCodeButtonVisible()));
+    connect(syncButtonVisible, SIGNAL(triggered()), this, SLOT(toggleSyncButtonVisible()));
 
     // note editor toolbar items begin
     fontNames = new FontNameComboBox(this);
@@ -324,6 +328,9 @@ EditorButtonBar::EditorButtonBar(QWidget *parent) :
     formatCodeButtonAction = this->addAction(global.getIconResource(":formatCodeIcon"),
                                              tr("Format Code Block").append(tooltipInfo));
 
+    // this sync button doesn't need a shortcut; the main app window shortcut is global
+    syncButtonAction = this->addAction(global.getIconResource(":synchronizeIcon"), tr("Sync"));
+
     QString css = global.getThemeCss("editorButtonBarCss");
     if (css != "")
         this->setStyleSheet(css);
@@ -353,6 +360,7 @@ EditorButtonBar::~EditorButtonBar() {
     delete fontVisible;
     delete fontSizeVisible;
     delete todoVisible;
+    delete syncButtonVisible;
 }
 
 
@@ -459,6 +467,9 @@ void EditorButtonBar::saveButtonbarState() {
     value = formatCodeButtonAction->isVisible();
     global.settings->setValue("formatCodeButtonVisible", value);
 
+    value = syncButtonAction->isVisible();
+    global.settings->setValue("syncButtonVisible", value);
+
     QString valueS = fontColorMenuWidget->getCurrentColorName();
     global.settings->setValue("fontColor", valueS);
     valueS = highlightColorMenuWidget->getCurrentColorName();
@@ -564,6 +575,8 @@ void EditorButtonBar::getButtonbarState() {
     formatCodeButtonAction->setVisible(global.settings->value("formatCodeButtonVisible", false).toBool());
     formatCodeButtonVisible->setChecked(formatCodeButtonAction->isVisible());
 
+    syncButtonAction->setVisible(global.settings->value("syncButtonVisible", true).toBool());
+    syncButtonVisible->setChecked(syncButtonAction->isVisible());
 
     global.settings->endGroup();
 }
@@ -733,6 +746,10 @@ void EditorButtonBar::toggleFormatCodeButtonVisible() {
     saveButtonbarState();
 }
 
+void EditorButtonBar::toggleSyncButtonVisible() {
+    syncButtonAction->setVisible(syncButtonVisible->isChecked());
+    saveButtonbarState();
+}
 
 // Load the list of font names
 void EditorButtonBar::loadFontNames() {
@@ -839,4 +856,5 @@ void EditorButtonBar::reloadIcons() {
     insertTableButtonAction->setIcon(global.getIconResource(":gridIcon"));
     htmlEntitiesButtonAction->setIcon(global.getIconResource(":htmlentitiesIcon"));
     formatCodeButtonAction->setIcon(global.getIconResource(":formatCodeIcon"));
+    syncButtonAction->setIcon(global.getIconResource(":synchronizeIcon"));
 }

--- a/src/gui/browserWidgets/editorbuttonbar.h
+++ b/src/gui/browserWidgets/editorbuttonbar.h
@@ -69,6 +69,7 @@ public:
     QAction *subscriptVisible;
     QAction *superscriptVisible;
     QAction *formatCodeButtonVisible;
+    QAction *syncButtonVisible;
 
     QAction *removeFormatButtonAction;
     QShortcut * removeFormatButtonShortcut;
@@ -130,8 +131,8 @@ public:
     QAction *htmlEntitiesButtonAction;
     QShortcut *htmlEntitiesButtonShortcut;
     QAction *formatCodeButtonAction;
-
     QShortcut *formatCodeButtonShortcut;
+    QAction *syncButtonAction;
 
     FontNameComboBox *fontNames;
     FontSizeComboBox *fontSizes;
@@ -193,6 +194,7 @@ public slots:
     void loadFontSizeComboBox(QString font);
     void loadFontNames();
     void toggleFormatCodeButtonVisible();
+    void toggleSyncButtonVisible();
 
 };
 

--- a/src/gui/nbrowserwindow.cpp
+++ b/src/gui/nbrowserwindow.cpp
@@ -1,5 +1,5 @@
 /*********************************************************************************
-NixNote - An open-source client for the Evernote service.
+NixNote - An open-source client f`or the Evernote service.
 Copyright (C) 2013 Randy Baumgarte
 
 This program is free software; you can redistribute it and/or
@@ -18,6 +18,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 ***********************************************************************************/
 
 #include "nbrowserwindow.h"
+#include "src/nixnote.h"
 #include "src/sql/notetable.h"
 #include "src/sql/notebooktable.h"
 #include "src/gui/browserWidgets/urleditor.h"
@@ -419,6 +420,9 @@ void NBrowserWindow::setupToolBar() {
 
     connect(buttonBar->formatCodeButtonAction, SIGNAL(triggered()), this, SLOT(formatCodeButtonPressed()));
     connect(buttonBar->formatCodeButtonShortcut, SIGNAL(activated()), this, SLOT(formatCodeButtonPressed()));
+
+    // this sync button doesn't need a shortcut; the main app window shortcut is global
+    connect(buttonBar->syncButtonAction, SIGNAL(triggered()), this, SLOT(syncButtonPressed()));
 }
 
 // Load the note content into the window
@@ -1265,7 +1269,7 @@ void NBrowserWindow::alignCenterButtonPressed() {
 }
 
 
-// The center align button was pressed
+// The format code button was pressed
 void NBrowserWindow::formatCodeButtonPressed() {
 
     QString text = editor->selectedText();
@@ -1285,6 +1289,10 @@ void NBrowserWindow::formatCodeButtonPressed() {
 
 }
 
+// The sync button was pressed
+void NBrowserWindow::syncButtonPressed() {
+    NixNote::get()->synchronize();
+}
 
 // The full align button was pressed
 void NBrowserWindow::alignFullButtonPressed() {

--- a/src/gui/nbrowserwindow.h
+++ b/src/gui/nbrowserwindow.h
@@ -279,6 +279,7 @@ public slots:
     void rotateImageRightButtonPressed();
     void removeFormatButtonPressed();
     void formatCodeButtonPressed();
+    void syncButtonPressed();
     void linkClicked(const QUrl url);
     void toggleSource();
     void setSource();

--- a/src/gui/nmainmenubar.cpp
+++ b/src/gui/nmainmenubar.cpp
@@ -441,7 +441,6 @@ void NMainMenuBar::setupToolsMenu() {
     synchronizeAction = new QAction(tr("&Synchronize"), this);
     synchronizeAction->setToolTip(tr("Synchronize with Evernote"));
     connect(synchronizeAction, SIGNAL(triggered()), parent, SLOT(synchronize()));
-    setupShortcut(synchronizeAction, QString("Tools_Synchronize"));
     toolsMenu->addAction(synchronizeAction);
 
     disconnectAction = new QAction(tr("&Disconnect"), this);

--- a/src/nixnote.h
+++ b/src/nixnote.h
@@ -80,6 +80,7 @@ class NixNote : public QMainWindow
     Q_OBJECT
 
 private:
+    static NixNote *singleton;  // static pointer to singleton instance of this class
     QTranslator *nixnoteTranslator;
     QWebView *pdfExportWindow;
     DatabaseConnection *db;  // The database connection
@@ -161,6 +162,7 @@ private:
     QShortcut *downNoteShortcut;
     QShortcut *upNoteShortcut;
     QShortcut *homeButtonShortcut;
+    QShortcut *syncButtonShortcut;
     QShortcut *leftArrowButtonShortcut;
     QShortcut *rightArrowButtonShortcut;
 
@@ -188,6 +190,7 @@ private:
 public:
     NixNote(QWidget *parent = 0);  // Constructor
     ~NixNote();   //Destructor
+    static NixNote *get();      // Public Singleton getter
     SyncRunner syncRunner;
     QThread syncThread;
     QThread indexThread;


### PR DESCRIPTION
Make the sync shortcut key global to all app windows, and add sync toolbar button to all editor windows.
**build-with-qmake.sh**
Turn on parallel build with 8 cores (8x faster builds on my dev box).
Add build "clean"
**nixnote.{h,cpp}**
Add singleton getter, so child windows can invoke synchronize() on the right instance.
Add Sync shortcut to the toolbar icon (used to be attached to the menu item).
**nmainmenubar.cpp**
Remove shortcut from sync menu item (it moved to the main toolbar).
**editorbuttonbar.{h,cpp}**
Add sync to the toolbar, with related code to select on menu, visibility, etc.
**nbrowserwindow.{h,cpp}**
Fix old copy/paste type on comment.
Add code to trigger when sync toolbar button is clicked.