### PR TITLE
Improve Note Email

### DIFF
--- a/src/gui/browserWidgets/editorbuttonbar.cpp
+++ b/src/gui/browserWidgets/editorbuttonbar.cpp
@@ -70,6 +70,7 @@ EditorButtonBar::EditorButtonBar(QWidget *parent) :
     htmlEntitiesButtonVisible = contextMenu->addAction(tr("HTML Entities"));
     formatCodeButtonVisible = contextMenu->addAction(tr("Format Code Block"));
     syncButtonVisible = contextMenu->addAction(tr("Sync"));
+    emailButtonVisible = contextMenu->addAction(tr("Email Note"));
 
     undoVisible->setCheckable(true);
     redoVisible->setCheckable(true);
@@ -105,6 +106,7 @@ EditorButtonBar::EditorButtonBar(QWidget *parent) :
     insertDatetimeVisible->setCheckable(true);
     formatCodeButtonVisible->setCheckable(true);
     syncButtonVisible->setCheckable(true);
+    emailButtonVisible->setCheckable(true);
 
     connect(undoVisible, SIGNAL(triggered()), this, SLOT(toggleUndoButtonVisible()));
     connect(redoVisible, SIGNAL(triggered()), this, SLOT(toggleRedoButtonVisible()));
@@ -138,6 +140,7 @@ EditorButtonBar::EditorButtonBar(QWidget *parent) :
     connect(htmlEntitiesButtonVisible, SIGNAL(triggered()), this, SLOT(toggleHtmlEntitiesButtonVisible()));
     connect(formatCodeButtonVisible, SIGNAL(triggered()), this, SLOT(toggleFormatCodeButtonVisible()));
     connect(syncButtonVisible, SIGNAL(triggered()), this, SLOT(toggleSyncButtonVisible()));
+    connect(emailButtonVisible, SIGNAL(triggered()), this, SLOT(toggleEmailButtonVisible()));
 
     // note editor toolbar items begin
     fontNames = new FontNameComboBox(this);
@@ -331,6 +334,11 @@ EditorButtonBar::EditorButtonBar(QWidget *parent) :
     // this sync button doesn't need a shortcut; the main app window shortcut is global
     syncButtonAction = this->addAction(global.getIconResource(":synchronizeIcon"), tr("Sync"));
 
+    // email button & shortcut
+    emailButtonShortcut = new QShortcut(this);
+    tooltipInfo = global.setupShortcut(emailButtonShortcut, "File_Email");
+    emailButtonAction = this->addAction(global.getIconResource(":emailIcon"), tr("Email Note").append(tooltipInfo));
+
     QString css = global.getThemeCss("editorButtonBarCss");
     if (css != "")
         this->setStyleSheet(css);
@@ -361,6 +369,7 @@ EditorButtonBar::~EditorButtonBar() {
     delete fontSizeVisible;
     delete todoVisible;
     delete syncButtonVisible;
+    delete emailButtonVisible;
 }
 
 
@@ -470,6 +479,9 @@ void EditorButtonBar::saveButtonbarState() {
     value = syncButtonAction->isVisible();
     global.settings->setValue("syncButtonVisible", value);
 
+    value = emailButtonAction->isVisible();
+    global.settings->setValue("emailButtonVisible", value);
+
     QString valueS = fontColorMenuWidget->getCurrentColorName();
     global.settings->setValue("fontColor", valueS);
     valueS = highlightColorMenuWidget->getCurrentColorName();
@@ -577,6 +589,9 @@ void EditorButtonBar::getButtonbarState() {
 
     syncButtonAction->setVisible(global.settings->value("syncButtonVisible", true).toBool());
     syncButtonVisible->setChecked(syncButtonAction->isVisible());
+
+    emailButtonAction->setVisible(global.settings->value("emailButtonVisible", true).toBool());
+    emailButtonVisible->setChecked(syncButtonAction->isVisible());
 
     global.settings->endGroup();
 }
@@ -751,6 +766,11 @@ void EditorButtonBar::toggleSyncButtonVisible() {
     saveButtonbarState();
 }
 
+void EditorButtonBar::toggleEmailButtonVisible() {
+    emailButtonAction->setVisible(emailButtonVisible->isChecked());
+    saveButtonbarState();
+}
+
 // Load the list of font names
 void EditorButtonBar::loadFontNames() {
     if (global.forceWebFonts) {
@@ -857,4 +877,5 @@ void EditorButtonBar::reloadIcons() {
     htmlEntitiesButtonAction->setIcon(global.getIconResource(":htmlentitiesIcon"));
     formatCodeButtonAction->setIcon(global.getIconResource(":formatCodeIcon"));
     syncButtonAction->setIcon(global.getIconResource(":synchronizeIcon"));
+    emailButtonAction->setIcon(global.getIconResource(":emailIcon"));
 }

--- a/src/gui/browserWidgets/editorbuttonbar.h
+++ b/src/gui/browserWidgets/editorbuttonbar.h
@@ -70,6 +70,7 @@ public:
     QAction *superscriptVisible;
     QAction *formatCodeButtonVisible;
     QAction *syncButtonVisible;
+    QAction *emailButtonVisible;
 
     QAction *removeFormatButtonAction;
     QShortcut * removeFormatButtonShortcut;
@@ -133,6 +134,8 @@ public:
     QAction *formatCodeButtonAction;
     QShortcut *formatCodeButtonShortcut;
     QAction *syncButtonAction;
+    QAction *emailButtonAction;
+    QShortcut *emailButtonShortcut;
 
     FontNameComboBox *fontNames;
     FontSizeComboBox *fontSizes;
@@ -195,6 +198,7 @@ public slots:
     void loadFontNames();
     void toggleFormatCodeButtonVisible();
     void toggleSyncButtonVisible();
+    void toggleEmailButtonVisible();
 
 };
 

--- a/src/gui/nbrowserwindow.cpp
+++ b/src/gui/nbrowserwindow.cpp
@@ -423,6 +423,9 @@ void NBrowserWindow::setupToolBar() {
 
     // this sync button doesn't need a shortcut; the main app window shortcut is global
     connect(buttonBar->syncButtonAction, SIGNAL(triggered()), this, SLOT(syncButtonPressed()));
+
+    connect(buttonBar->emailButtonAction, SIGNAL(triggered()), this, SLOT(emailNote()));
+    connect(buttonBar->emailButtonShortcut, SIGNAL(activated()), this, SLOT(emailNote()));
 }
 
 // Load the note content into the window

--- a/src/gui/nmainmenubar.cpp
+++ b/src/gui/nmainmenubar.cpp
@@ -59,7 +59,6 @@ void NMainMenuBar::setupFileMenu() {
     emailAction = new QAction(tr("Email Note"), this);
     emailAction->setToolTip(tr("Email a copy of this note"));
     connect(emailAction, SIGNAL(triggered()), parent, SLOT(emailNote()));
-    setupShortcut(emailAction, QString("File_Email"));
     fileMenu->addAction(emailAction);
 
 


### PR DESCRIPTION
Make note emailing relative to each NBrowserWindow, instead of app global. This enables emailing from any open note window, instead of only from the main app screen. The email toolbar & the key shortcut are now both relative to every note window.
nmainmenubar.cpp: remove email shortcut key (but keep the toolbar button unchanged)
editorbuttonbar.*: add note email toolbar button & shortcut
nbrowserwindow.cpp: handle events from the new email button & shortcut