### PR TITLE
Fixed two issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,11 +199,13 @@ You need to build tidy-html5 by yourself to get the dll files, its README file m
 
 About hunspell, as its README instructs us to use MSYS2 and Cygwin, which may be in x64, so you had better pay attention to the host type when executing its configure script. To get compatible libraries, you have to set gcc and g++ as the one you used previously for tidy(by alias or export command) and run the configure script like this:
 ```bash
-./configure --build=i686-pc-mingw32 --host=i686-pc-mingw32 --target=i686-pc-mingw32
+MSYS2/Cygwin # autoreconf -vfi
+MSYS2/Cygwin # ./configure --build=i686-pc-mingw32 --host=i686-pc-mingw32 --target=i686-pc-mingw32
+MSYS2/Cygwin # mingw32-make.exe
 ```
-And then, execute 'mingw32-make.exe', and you will get the dll file.
+Then you will get the hunspell dll file.
 
-If your qt version is 5.5 or higher, you need to copy the files under QtWebKit include folder to /your_path_to_qt/[version]/mingw[version]/include. Then, create folders as winlib/includes in this repository folder and copy the files under poppler, tidy and hunspell include folders to winlib/includes. The structure is:
+If your qt version is 5.6 or higher, you need to copy the files under QtWebKit include folder to /your_path_to_qt/[version]/mingw[version]/include. Then, create folders as winlib/includes in this repository folder and copy the files under poppler, tidy and hunspell include folders to winlib/includes. The structure is:
 
 ```bash
 nixnote_repo

--- a/src/gui/nbrowserwindow.cpp
+++ b/src/gui/nbrowserwindow.cpp
@@ -976,7 +976,7 @@ void NBrowserWindow::pasteButtonPressed() {
 
     // note: pasted text - is text only version without html tags
     bool hasHtml = mime->hasHtml();
-    const QString mimeContentAsText = mime->text().trimmed();
+    const QString mimeContentAsText = mime->text();
     bool isEvernoteInAppLink = mimeContentAsText.startsWith("evernote:///view/");
     bool processAsHtml = hasHtml && (!isEvernoteInAppLink);
     QString textToPaste = processAsHtml ? mime->html() : mimeContentAsText;

--- a/src/threads/indexrunner.cpp
+++ b/src/threads/indexrunner.cpp
@@ -524,5 +524,5 @@ void IndexRunner::flushCache() {
 
 void IndexRunner::busy(bool value, bool finished) {
     iAmBusy=value;
-    emit(this->indexDone(finished));
+    emit(indexDone(finished));
 }


### PR DESCRIPTION
The issues are:
1. [issue #180](https://github.com/robert7/nixnote2/issues/180) : Can't search / replace with <space> as replacement.
2. Nixnote often crashes and prints: QObject::~QObject: Timers cannot be stopped from another thread. This is caused by an invalid access to a signal. This issue happens on Linux, not on Windows, because Windows edition signal handler code is disabled.

And I also updated the README.md.