### PR TITLE
Fixed the issues: editor fonts and sorting notes #156 and Search by date attributes not working with PPA builds #149

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,7 +253,18 @@ mingw32-make.exe
 strip.exe qmake-build-debug/[release]/nixnote2.exe
 ```
 
-Finally, you will get qmake-build-debug[/release]/nixnote2.exe. Run deploy-on-windows.sh located in the development folder with a destination folder to deploy as the parameter. If you need spell check, you have to download the dictionary files and copy the .aff and .dic file to the deployment folder. You may want to download them [here](https://github.com/wooorm/dictionaries).
+Finally, you will get qmake-build-debug[/release]/nixnote2.exe.
+
+#### Deployment:
+
+First, copy the nixnote2.exe to the deployment_folder, then execute the following commands:
+
+```bash
+windeployqt.exe --compiler-runtime --libdir [deployment_folder] [deployment_folder]
+bash /development/deploy-on-windows.sh [deployment_folder]
+```
+
+If you need spell check, you have to download the dictionary files and copy the .aff and .dic file to the deployment folder. You may want to download them [here](https://github.com/wooorm/dictionaries).
 
 
 ## Donations

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,4 +1,9 @@
 NixNote (2.1.7) stable; urgency=low
+  * Fixed: Search by date attributes not working with PPA builds - issue #149
+  * Fixed: Editor fonts and sorting notes - issue #156
+  * Fixed: Nixnote often crashes
+  * Fixed: Can't search / replace with as replacement. - issue #180
+  * Enabled the spell check code for Windows edition
   * Fixed Windows build (thanks to https://github.com/boo-yee)
  -- Robert Spiegel <nightingale7@gmail.com>  Tue, 17 May 2022 10:00:00 +0200
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,9 @@
 NixNote (2.1.7) stable; urgency=low
+  * Fixed: Search by date attributes not working with PPA builds - issue #149
+  * Fixed: Editor fonts and sorting notes - issue #156
+  * Fixed: Nixnote often crashes
+  * Fixed: Can't search / replace with as replacement. - issue #180
+  * Enabled the spell check code for Windows edition
   * Fixed Windows build (thanks to https://github.com/boo-yee)
  -- Robert Spiegel <nightingale7@gmail.com>  Tue, 17 May 2022 10:00:00 +0200
 

--- a/development/deploy-on-windows.sh
+++ b/development/deploy-on-windows.sh
@@ -54,30 +54,4 @@ done
 
 cp -r -n ../translations ../resources/images ../java ../themes.ini ../colors.txt ../shortcuts.txt $deploy_folder
 
-
-choice=1
-if [ -f "../qmake-build-release/nixnote2.exe" ] && [ -f "../qmake-build-debug/nixnote2.exe" ];
-then
-    echo "Found two executables, please choose one. 1. ../qmake-build-release/nixnote2.exe; 2. ../qmake-build-build/nixnote2.exe [1]/2?:"
-    read choice
-    if [[ $choice == 1 ]]; then
-        cp ../qmake-build-release/nixnote2.exe $deploy_folder 
-    elif [[ $choice == 2 ]]; then
-        cp ../qmake-build-debug/nixnote2.exe $deploy_folder 
-    else
-        echo "Unknown input. Deploy release version as default."
-        cp ../qmake-build-release/nixnote2.exe $deploy_folder 
-    fi
-    echo "Deployment finished."
-    exit 0
-fi
-
-if [ -f "../qmake-build-release/nixnote2.exe" ]; then
-    cp ../qmake-build-release/nixnote2.exe $deploy_folder 
-fi
-
-if [ -f "../qmake-build-debug/nixnote2.exe" ]; then
-    cp ../qmake-build-debug/nixnote2.exe $deploy_folder 
-fi
-
 echo "Deployment finished."

--- a/src/filters/filterengine.cpp
+++ b/src/filters/filterengine.cpp
@@ -240,11 +240,13 @@ void FilterEngine::filter(FilterCriteria *newCriteria, QList<qint32> *results) {
 
 
 void FilterEngine::filterAttributes(FilterCriteria *criteria) {
-    if (!criteria->isSet() || !criteria->isAttributeSet())
+    if (!criteria->isSet() || !criteria->isAttributeSet()) {
         return;
+    }
     QLOG_TRACE_IN();
 
     int attribute = criteria->getAttribute()->data(0,Qt::UserRole).toInt();
+
     NSqlQuery sql(global.db);
     QDateTime dt;
     dt.setDate(QDate().currentDate());
@@ -256,45 +258,45 @@ void FilterEngine::filterAttributes(FilterCriteria *criteria) {
     switch (attribute)
     {
     case CREATED_SINCE_TODAY:
-        sql.prepare("Delete from filter where lid not in (select lid from DataStore where key=:key and datetime(data/1000)>(datetime(:data/1000)))");
+        sql.prepare("Delete from filter where lid not in (select lid from DataStore where key=:key and (data/1000)>((:data/1000)))");
         sql.bindValue(":key", NOTE_CREATED_DATE);
         sql.bindValue(":data", dt.toMSecsSinceEpoch());
         break;
     case CREATED_SINCE_YESTERDAY:
         dt = dt.addDays(-1);
-        sql.prepare("Delete from filter where lid not in (select lid from DataStore where key=:key and datetime(data/1000)>(datetime(:data/1000)))");;
+        sql.prepare("Delete from filter where lid not in (select lid from DataStore where key=:key and (data/1000)>((:data/1000)))");
         sql.bindValue(":key", NOTE_CREATED_DATE);
         sql.bindValue(":data", dt.toMSecsSinceEpoch());
         break;
     case CREATED_SINCE_THIS_WEEK:
         dt = dt.addDays(-1*dow);
-        sql.prepare("Delete from filter where lid not in (select lid from DataStore where key=:key and datetime(data/1000)>(datetime(:data/1000)))");;
+        sql.prepare("Delete from filter where lid not in (select lid from DataStore where key=:key and (data/1000)>((:data/1000)))");
         sql.bindValue(":key", NOTE_CREATED_DATE);
         sql.bindValue(":data", dt.toMSecsSinceEpoch());
         break;
     case CREATED_SINCE_LAST_WEEK:
         dt = dt.addDays(-1*dow-7);
-        sql.prepare("Delete from filter where lid not in (select lid from DataStore where key=:key and datetime(data/1000)>(datetime(:data/1000)))");;
+        sql.prepare("Delete from filter where lid not in (select lid from DataStore where key=:key and (data/1000)>((:data/1000)))");
         sql.bindValue(":key", NOTE_CREATED_DATE);
         sql.bindValue(":data", dt.toMSecsSinceEpoch());
         break;
     case CREATED_SINCE_THIS_MONTH:
         dt = dt.addDays(-1*dom+1);
-        sql.prepare("Delete from filter where lid not in (select lid from DataStore where key=:key and datetime(data/1000)>(datetime(:data/1000)))");;
+        sql.prepare("Delete from filter where lid not in (select lid from DataStore where key=:key and (data/1000)>((:data/1000)))");
         sql.bindValue(":key", NOTE_CREATED_DATE);
         sql.bindValue(":data", dt.toMSecsSinceEpoch());
         break;
     case CREATED_SINCE_LAST_MONTH:
         dt = dt.addDays(-1*dom+1);
         dt = dt.addMonths(-1);
-        sql.prepare("Delete from filter where lid not in (select lid from DataStore where key=:key and datetime(data/1000)>(datetime(:data/1000)))");;
+        sql.prepare("Delete from filter where lid not in (select lid from DataStore where key=:key and (data/1000)>((:data/1000)))");
         sql.bindValue(":key", NOTE_CREATED_DATE);
         sql.bindValue(":data", dt.toMSecsSinceEpoch());
         break;
     case CREATED_SINCE_THIS_YEAR:
         dt = dt.addDays(-1*dom+1);
         dt = dt.addMonths(-1*moy+1);
-        sql.prepare("Delete from filter where lid not in (select lid from DataStore where key=:key and datetime(data/1000)>(datetime(:data/1000)))");;
+        sql.prepare("Delete from filter where lid not in (select lid from DataStore where key=:key and (data/1000)>((:data/1000)))");
         sql.bindValue(":key", NOTE_CREATED_DATE);
         sql.bindValue(":data", dt.toMSecsSinceEpoch());
         break;
@@ -302,50 +304,50 @@ void FilterEngine::filterAttributes(FilterCriteria *criteria) {
         dt = dt.addDays(-1*dom+1);
         dt = dt.addMonths(-1*moy+1);
         dt = dt.addYears(-1);
-        sql.prepare("Delete from filter where lid not in (select lid from DataStore where key=:key and datetime(data/1000)>(datetime(:data/1000)))");;
+        sql.prepare("Delete from filter where lid not in (select lid from DataStore where key=:key and (data/1000)>((:data/1000)))");
         sql.bindValue(":key", NOTE_CREATED_DATE);
         sql.bindValue(":data", dt.toMSecsSinceEpoch());
         break;
     case CREATED_BEFORE_TODAY:
-        sql.prepare("Delete from filter where lid not in (select lid from DataStore where key=:key and datetime(data/1000)<(datetime(:data/1000)))");
+        sql.prepare("Delete from filter where lid not in (select lid from DataStore where key=:key and (data/1000)<((:data/1000)))");
         sql.bindValue(":key", NOTE_CREATED_DATE);
         sql.bindValue(":data", dt.toMSecsSinceEpoch());
         break;
     case CREATED_BEFORE_YESTERDAY:
         dt = dt.addDays(-1);
-        sql.prepare("Delete from filter where lid not in (select lid from DataStore where key=:key and datetime(data/1000)<(datetime(:data/1000)))");;
+        sql.prepare("Delete from filter where lid not in (select lid from DataStore where key=:key and (data/1000)<((:data/1000)))");
         sql.bindValue(":key", NOTE_CREATED_DATE);
         sql.bindValue(":data", dt.toMSecsSinceEpoch());
         break;
     case CREATED_BEFORE_THIS_WEEK:
         dt = dt.addDays(-1*dow);
-        sql.prepare("Delete from filter where lid not in (select lid from DataStore where key=:key and datetime(data/1000)<(datetime(:data/1000)))");;
+        sql.prepare("Delete from filter where lid not in (select lid from DataStore where key=:key and (data/1000)<((:data/1000)))");
         sql.bindValue(":key", NOTE_CREATED_DATE);
         sql.bindValue(":data", dt.toMSecsSinceEpoch());
         break;
     case CREATED_BEFORE_LAST_WEEK:
         dt = dt.addDays(-1*dow-7);
-        sql.prepare("Delete from filter where lid not in (select lid from DataStore where key=:key and datetime(data/1000)<(datetime(:data/1000)))");;
+        sql.prepare("Delete from filter where lid not in (select lid from DataStore where key=:key and (data/1000)<((:data/1000)))");
         sql.bindValue(":key", NOTE_CREATED_DATE);
         sql.bindValue(":data", dt.toMSecsSinceEpoch());
         break;
     case CREATED_BEFORE_THIS_MONTH:
         dt = dt.addDays(-1*dom+1);
-        sql.prepare("Delete from filter where lid not in (select lid from DataStore where key=:key and datetime(data/1000)<(datetime(:data/1000)))");;
+        sql.prepare("Delete from filter where lid not in (select lid from DataStore where key=:key and (data/1000)<((:data/1000)))");
         sql.bindValue(":key", NOTE_CREATED_DATE);
         sql.bindValue(":data", dt.toMSecsSinceEpoch());
         break;
     case CREATED_BEFORE_LAST_MONTH:
         dt = dt.addDays(-1*dom+1);
         dt = dt.addMonths(-1);
-        sql.prepare("Delete from filter where lid not in (select lid from DataStore where key=:key and datetime(data/1000)<(datetime(:data/1000)))");;
+        sql.prepare("Delete from filter where lid not in (select lid from DataStore where key=:key and (data/1000)<((:data/1000)))");
         sql.bindValue(":key", NOTE_CREATED_DATE);
         sql.bindValue(":data", dt.toMSecsSinceEpoch());
         break;
     case CREATED_BEFORE_THIS_YEAR:
         dt = dt.addDays(-1*dom+1);
         dt = dt.addMonths(-1*moy+1);
-        sql.prepare("Delete from filter where lid not in (select lid from DataStore where key=:key and datetime(data/1000)<(datetime(:data/1000)))");;
+        sql.prepare("Delete from filter where lid not in (select lid from DataStore where key=:key and (data/1000)<((:data/1000)))");
         sql.bindValue(":key", NOTE_CREATED_DATE);
         sql.bindValue(":data", dt.toMSecsSinceEpoch());
         break;
@@ -353,50 +355,50 @@ void FilterEngine::filterAttributes(FilterCriteria *criteria) {
         dt = dt.addDays(-1*dom+1);
         dt = dt.addMonths(-1*moy+1);
         dt = dt.addYears(-1);
-        sql.prepare("Delete from filter where lid not in (select lid from DataStore where key=:key and datetime(data/1000)<(datetime(:data/1000)))");;
+        sql.prepare("Delete from filter where lid not in (select lid from DataStore where key=:key and (data/1000)<((:data/1000)))");
         sql.bindValue(":key", NOTE_CREATED_DATE);
         sql.bindValue(":data", dt.toMSecsSinceEpoch());
         break;
     case MODIFIED_SINCE_TODAY:
-        sql.prepare("Delete from filter where lid not in (select lid from DataStore where key=:key and datetime(data/1000)>(datetime(:data/1000)))");
+        sql.prepare("Delete from filter where lid not in (select lid from DataStore where key=:key and (data/1000)>((:data/1000)))");
         sql.bindValue(":key", NOTE_UPDATED_DATE);
         sql.bindValue(":data", dt.toMSecsSinceEpoch());
         break;
     case MODIFIED_SINCE_YESTERDAY:
         dt = dt.addDays(-1);
-        sql.prepare("Delete from filter where lid not in (select lid from DataStore where key=:key and datetime(data/1000)>(datetime(:data/1000)))");;
+        sql.prepare("Delete from filter where lid not in (select lid from DataStore where key=:key and (data/1000)>((:data/1000)))");
         sql.bindValue(":key", NOTE_UPDATED_DATE);
         sql.bindValue(":data", dt.toMSecsSinceEpoch());
         break;
     case MODIFIED_SINCE_THIS_WEEK:
         dt = dt.addDays(-1*dow);
-        sql.prepare("Delete from filter where lid not in (select lid from DataStore where key=:key and datetime(data/1000)>(datetime(:data/1000)))");;
+        sql.prepare("Delete from filter where lid not in (select lid from DataStore where key=:key and (data/1000)>((:data/1000)))");
         sql.bindValue(":key", NOTE_UPDATED_DATE);
         sql.bindValue(":data", dt.toMSecsSinceEpoch());
         break;
     case MODIFIED_SINCE_LAST_WEEK:
         dt = dt.addDays(-1*dow-7);
-        sql.prepare("Delete from filter where lid not in (select lid from DataStore where key=:key and datetime(data/1000)>(datetime(:data/1000)))");;
+        sql.prepare("Delete from filter where lid not in (select lid from DataStore where key=:key and (data/1000)>((:data/1000)))");
         sql.bindValue(":key", NOTE_UPDATED_DATE);
         sql.bindValue(":data", dt.toMSecsSinceEpoch());
         break;
     case MODIFIED_SINCE_THIS_MONTH:
         dt = dt.addDays(-1*dom+1);
-        sql.prepare("Delete from filter where lid not in (select lid from DataStore where key=:key and datetime(data/1000)>(datetime(:data/1000)))");;
+        sql.prepare("Delete from filter where lid not in (select lid from DataStore where key=:key and (data/1000)>((:data/1000)))");
         sql.bindValue(":key", NOTE_UPDATED_DATE);
         sql.bindValue(":data", dt.toMSecsSinceEpoch());
         break;
     case MODIFIED_SINCE_LAST_MONTH:
         dt = dt.addDays(-1*dom+1);
         dt = dt.addMonths(-1);
-        sql.prepare("Delete from filter where lid not in (select lid from DataStore where key=:key and datetime(data/1000)>(datetime(:data/1000)))");;
+        sql.prepare("Delete from filter where lid not in (select lid from DataStore where key=:key and (data/1000)>((:data/1000)))");
         sql.bindValue(":key", NOTE_UPDATED_DATE);
         sql.bindValue(":data", dt.toMSecsSinceEpoch());
         break;
     case MODIFIED_SINCE_THIS_YEAR:
         dt = dt.addDays(-1*dom+1);
         dt = dt.addMonths(-1*moy+1);
-        sql.prepare("Delete from filter where lid not in (select lid from DataStore where key=:key and datetime(data/1000)>(datetime(:data/1000)))");;
+        sql.prepare("Delete from filter where lid not in (select lid from DataStore where key=:key and (data/1000)>((:data/1000)))");
         sql.bindValue(":key", NOTE_UPDATED_DATE);
         sql.bindValue(":data", dt.toMSecsSinceEpoch());
         break;
@@ -404,50 +406,50 @@ void FilterEngine::filterAttributes(FilterCriteria *criteria) {
         dt = dt.addDays(-1*dom+1);
         dt = dt.addMonths(-1*moy+1);
         dt = dt.addYears(-1);
-        sql.prepare("Delete from filter where lid not in (select lid from DataStore where key=:key and datetime(data/1000)>(datetime(:data/1000)))");;
+        sql.prepare("Delete from filter where lid not in (select lid from DataStore where key=:key and (data/1000)>((:data/1000)))");
         sql.bindValue(":key", NOTE_UPDATED_DATE);
         sql.bindValue(":data", dt.toMSecsSinceEpoch());
         break;
     case MODIFIED_BEFORE_TODAY:
-        sql.prepare("Delete from filter where lid not in (select lid from DataStore where key=:key and datetime(data/1000)<(datetime(:data/1000)))");
+        sql.prepare("Delete from filter where lid not in (select lid from DataStore where key=:key and (data/1000)<((:data/1000)))");
         sql.bindValue(":key", NOTE_UPDATED_DATE);
         sql.bindValue(":data", dt.toMSecsSinceEpoch());
         break;
     case MODIFIED_BEFORE_YESTERDAY:
         dt = dt.addDays(-1);
-        sql.prepare("Delete from filter where lid not in (select lid from DataStore where key=:key and datetime(data/1000)<(datetime(:data/1000)))");;
+        sql.prepare("Delete from filter where lid not in (select lid from DataStore where key=:key and (data/1000)<((:data/1000)))");
         sql.bindValue(":key", NOTE_UPDATED_DATE);
         sql.bindValue(":data", dt.toMSecsSinceEpoch());
         break;
     case MODIFIED_BEFORE_THIS_WEEK:
         dt = dt.addDays(-1*dow);
-        sql.prepare("Delete from filter where lid not in (select lid from DataStore where key=:key and datetime(data/1000)<(datetime(:data/1000)))");;
+        sql.prepare("Delete from filter where lid not in (select lid from DataStore where key=:key and (data/1000)<((:data/1000)))");
         sql.bindValue(":key", NOTE_UPDATED_DATE);
         sql.bindValue(":data", dt.toMSecsSinceEpoch());
         break;
     case MODIFIED_BEFORE_LAST_WEEK:
         dt = dt.addDays(-1*dow-7);
-        sql.prepare("Delete from filter where lid not in (select lid from DataStore where key=:key and datetime(data/1000)<(datetime(:data/1000)))");;
+        sql.prepare("Delete from filter where lid not in (select lid from DataStore where key=:key and (data/1000)<((:data/1000)))");
         sql.bindValue(":key", NOTE_UPDATED_DATE);
         sql.bindValue(":data", dt.toMSecsSinceEpoch());
         break;
     case MODIFIED_BEFORE_THIS_MONTH:
         dt = dt.addDays(-1*dom+1);
-        sql.prepare("Delete from filter where lid not in (select lid from DataStore where key=:key and datetime(data/1000)<(datetime(:data/1000)))");;
+        sql.prepare("Delete from filter where lid not in (select lid from DataStore where key=:key and (data/1000)<((:data/1000)))");
         sql.bindValue(":key", NOTE_UPDATED_DATE);
         sql.bindValue(":data", dt.toMSecsSinceEpoch());
         break;
     case MODIFIED_BEFORE_LAST_MONTH:
         dt = dt.addDays(-1*dom+1);
         dt = dt.addMonths(-1);
-        sql.prepare("Delete from filter where lid not in (select lid from DataStore where key=:key and datetime(data/1000)<(datetime(:data/1000)))");;
+        sql.prepare("Delete from filter where lid not in (select lid from DataStore where key=:key and (data/1000)<((:data/1000)))");
         sql.bindValue(":key", NOTE_UPDATED_DATE);
         sql.bindValue(":data", dt.toMSecsSinceEpoch());
         break;
     case MODIFIED_BEFORE_THIS_YEAR:
         dt = dt.addDays(-1*dom+1);
         dt = dt.addMonths(-1*moy+1);
-        sql.prepare("Delete from filter where lid not in (select lid from DataStore where key=:key and datetime(data/1000)<(datetime(:data/1000)))");;
+        sql.prepare("Delete from filter where lid not in (select lid from DataStore where key=:key and (data/1000)<((:data/1000)))");
         sql.bindValue(":key", NOTE_UPDATED_DATE);
         sql.bindValue(":data", dt.toMSecsSinceEpoch());
         break;
@@ -455,7 +457,7 @@ void FilterEngine::filterAttributes(FilterCriteria *criteria) {
         dt = dt.addDays(-1*dom+1);
         dt = dt.addMonths(-1*moy+1);
         dt = dt.addYears(-1);
-        sql.prepare("Delete from filter where lid not in (select lid from DataStore where key=:key and datetime(data/1000)<(datetime(:data/1000)))");;
+        sql.prepare("Delete from filter where lid not in (select lid from DataStore where key=:key and (data/1000)<((:data/1000)))");
         sql.bindValue(":key", NOTE_UPDATED_DATE);
         sql.bindValue(":data", dt.toMSecsSinceEpoch());
         break;
@@ -1594,27 +1596,27 @@ void FilterEngine::filterSearchStringDateAll(QString string) {
     int key=0;
 
     if (string.startsWith("created:", Qt::CaseInsensitive)) {
-        sql.prepare("Delete from filter where lid not in (select lid from DataStore where key=:key and datetime(data/1000)>=(datetime(:data/1000)))");;
+        sql.prepare("Delete from filter where lid not in (select lid from DataStore where key=:key and (data/1000)>=((:data/1000)))");
         key = NOTE_CREATED_DATE;
     }
     else if (string.startsWith("updated:", Qt::CaseInsensitive)) {
-        sql.prepare("Delete from filter where lid not in (select lid from DataStore where key=:key and datetime(data/1000)>=(datetime(:data/1000)))");;
+        sql.prepare("Delete from filter where lid not in (select lid from DataStore where key=:key and (data/1000)>=((:data/1000)))");
         key = NOTE_UPDATED_DATE;
     }
     else if (string.startsWith("subjectdate:", Qt::CaseInsensitive)) {
-        sql.prepare("Delete from filter where lid not in (select lid from DataStore where key=:key and datetime(data/1000)>=(datetime(:data/1000)))");;
+        sql.prepare("Delete from filter where lid not in (select lid from DataStore where key=:key and (data/1000)>=((:data/1000)))");
         key = NOTE_ATTRIBUTE_SUBJECT_DATE;
     }
     else if (string.startsWith("-created:", Qt::CaseInsensitive)) {
-        sql.prepare("Delete from filter where lid in (select lid from DataStore where key=:key and datetime(data/1000)<=(datetime(:data/1000)))");;
+        sql.prepare("Delete from filter where lid in (select lid from DataStore where key=:key and (data/1000)<=((:data/1000)))");
         key = NOTE_CREATED_DATE;
     }
     else if (string.startsWith("-updated:", Qt::CaseInsensitive)) {
-        sql.prepare("Delete from filter where lid in (select lid from DataStore where key=:key and datetime(data/1000)<=(datetime(:data/1000)))");;
+        sql.prepare("Delete from filter where lid in (select lid from DataStore where key=:key and (data/1000)<=((:data/1000)))");
         key = NOTE_UPDATED_DATE;
     }
     else if (string.startsWith("-subjectdate:", Qt::CaseInsensitive)) {
-        sql.prepare("Delete from filter where lid in (select lid from DataStore where key=:key and datetime(data/1000)<=(datetime(:data/1000)))");;
+        sql.prepare("Delete from filter where lid in (select lid from DataStore where key=:key and (data/1000)<=((:data/1000)))");
         key = NOTE_ATTRIBUTE_SUBJECT_DATE;
     }
 
@@ -2201,27 +2203,27 @@ void FilterEngine::filterSearchStringDateAny(QString string) {
     int key=0;
 
     if (string.startsWith("created:", Qt::CaseInsensitive)) {
-        sql.prepare("insert into anylidsfilter (lid) select lid from DataStore where key=:key and datetime(data/1000)>=(datetime(:data/1000))");
+        sql.prepare("insert into anylidsfilter (lid) select lid from DataStore where key=:key and (data/1000)>=((:data/1000))");
         key = NOTE_CREATED_DATE;
     }
     else if (string.startsWith("updated:", Qt::CaseInsensitive)) {
-        sql.prepare("insert into anylidsfilter (lid) select lid from DataStore where key=:key and datetime(data/1000)>=(datetime(:data/1000))");
+        sql.prepare("insert into anylidsfilter (lid) select lid from DataStore where key=:key and (data/1000)>=((:data/1000))");
         key = NOTE_UPDATED_DATE;
     }
     else if (string.startsWith("subjectdate:", Qt::CaseInsensitive)) {
-        sql.prepare("insert into anylidsfilter (lid) select lid from DataStore where key=:key and datetime(data/1000)>=(datetime(:data/1000))");
+        sql.prepare("insert into anylidsfilter (lid) select lid from DataStore where key=:key and (data/1000)>=((:data/1000))");
         key = NOTE_ATTRIBUTE_SUBJECT_DATE;
     }
     else if (string.startsWith("-created:", Qt::CaseInsensitive)) {
-        sql.prepare("insert into anylidsfilter (lid) select lid from DataStore where key=:key and datetime(data/1000)<=(datetime(:data/1000))");
+        sql.prepare("insert into anylidsfilter (lid) select lid from DataStore where key=:key and (data/1000)<=((:data/1000))");
         key = NOTE_CREATED_DATE;
     }
     else if (string.startsWith("-updated:", Qt::CaseInsensitive)) {
-        sql.prepare("insert into anylidsfilter (lid) select lid from DataStore where key=:key and datetime(data/1000)<=(datetime(:data/1000))");
+        sql.prepare("insert into anylidsfilter (lid) select lid from DataStore where key=:key and (data/1000)<=((:data/1000))");
         key = NOTE_UPDATED_DATE;
     }
     else if (string.startsWith("-subjectdate:", Qt::CaseInsensitive)) {
-        sql.prepare("insert into anylidsfilter (lid) select lid from DataStore where key=:key and datetime(data/1000)<=(datetime(:data/1000))");
+        sql.prepare("insert into anylidsfilter (lid) select lid from DataStore where key=:key and (data/1000)<=((:data/1000))");
         key = NOTE_ATTRIBUTE_SUBJECT_DATE;
     }
 
@@ -2511,9 +2513,9 @@ void FilterEngine::filterSearchStringReminderTimeAll(QString string) {
     int key= NOTE_ATTRIBUTE_REMINDER_TIME;
 
     if (string.startsWith("-", Qt::CaseInsensitive)) {
-        sql.prepare("Delete from filter where lid not in (select lid from DataStore where key=:key and datetime(data/1000)<(datetime(:data/1000)))");;
+        sql.prepare("Delete from filter where lid not in (select lid from DataStore where key=:key and (data/1000)<((:data/1000)))");
     } else {
-        sql.prepare("Delete from filter where lid not in (select lid from DataStore where key=:key and datetime(data/1000)>=(datetime(:data/1000)))");;
+        sql.prepare("Delete from filter where lid not in (select lid from DataStore where key=:key and (data/1000)>=((:data/1000)))");
     }
 
     sql.bindValue(":key", key);
@@ -2534,9 +2536,9 @@ void FilterEngine::filterSearchStringReminderTimeAny(QString string) {
     int key = NOTE_ATTRIBUTE_REMINDER_TIME;
 
     if (string.startsWith("-reminderDoneTime:", Qt::CaseInsensitive)) {
-        sql.prepare("insert into anylidsfilter (lid) select lid from DataStore where key=:key and datetime(data/1000)<(datetime(:data/1000))");
+        sql.prepare("insert into anylidsfilter (lid) select lid from DataStore where key=:key and (data/1000)<((:data/1000))");
     } else {
-        sql.prepare("insert into anylidsfilter (lid) select lid from DataStore where key=:key and datetime(data/1000)>=(datetime(:data/1000))");
+        sql.prepare("insert into anylidsfilter (lid) select lid from DataStore where key=:key and (data/1000)>=((:data/1000))");
     }
     sql.bindValue(":key", key);
     sql.bindValue(":data", dt.toMSecsSinceEpoch());
@@ -2556,9 +2558,9 @@ void FilterEngine::filterSearchStringReminderDoneTimeAll(QString string) {
     int key = NOTE_ATTRIBUTE_REMINDER_DONE_TIME;
 
     if (string.startsWith("-", Qt::CaseInsensitive)) {
-        sql.prepare("Delete from filter where lid not in (select lid from DataStore where key=:key and datetime(data/1000)<(datetime(:data/1000)))");
+        sql.prepare("Delete from filter where lid not in (select lid from DataStore where key=:key and (data/1000)<((:data/1000)))");
     } else {
-        sql.prepare("Delete from filter where lid not in (select lid from DataStore where key=:key and datetime(data/1000)>=(datetime(:data/1000)))");
+        sql.prepare("Delete from filter where lid not in (select lid from DataStore where key=:key and (data/1000)>=((:data/1000)))");
     }
 
     sql.bindValue(":key", key);
@@ -2579,9 +2581,9 @@ void FilterEngine::filterSearchStringReminderDoneTimeAny(QString string) {
     int key = NOTE_ATTRIBUTE_REMINDER_DONE_TIME;
 
     if (string.startsWith("-reminderDoneTime:", Qt::CaseInsensitive)) {
-        sql.prepare("insert into anylidsfilter (lid) select lid from DataStore where key=:key and datetime(data/1000)<(datetime(:data/1000))");
+        sql.prepare("insert into anylidsfilter (lid) select lid from DataStore where key=:key and (data/1000)<((:data/1000))");
     } else {
-        sql.prepare("insert into anylidsfilter (lid) select lid from DataStore where key=:key and datetime(data/1000)>=(datetime(:data/1000))");
+        sql.prepare("insert into anylidsfilter (lid) select lid from DataStore where key=:key and (data/1000)>=((:data/1000))");
     }
     sql.bindValue(":key", key);
     sql.bindValue(":data", dt.toMSecsSinceEpoch());

--- a/src/gui/nbrowserwindow.cpp
+++ b/src/gui/nbrowserwindow.cpp
@@ -1406,30 +1406,6 @@ void NBrowserWindow::fontSizeSelected(int index) {
         text = "&zwnj;";
     }
 
-    // Go througth the selected HTML and strip out all of the existing font-sizes.
-    // This allows for the font size to be changed multiple times.  Without this the inner most font
-    // size would always win.
-    //for (int i = text.indexOf("<"); i >= 0; i = text.indexOf("<", i + 1)) {
-    //    QString text1 = "";
-    //    QString text2 = "";
-    //    text1 = text.mid(0, i);
-    //    QString interior = text.mid(i);
-    //    if (!interior.startsWith("</")) {
-    //        int endPos = text.indexOf(">", i);
-    //        if (endPos > 0) {
-    //            interior = text.mid(i, endPos - i);
-    //            text2 = text.mid(endPos);
-    //        }
-    //        // Now that we have a substring, look for the font-size
-    //        if (interior.contains("font-size:")) {
-    //            interior = interior.mid(0, interior.indexOf("font-size:")) +
-    //                       //QString::number(size)+
-    //                       interior.mid(interior.indexOf("pt;") + 3);
-    //            text = text1 + interior + text2;
-    //        }
-    //    }
-    //}
-
     // Start building a new font span.
     int idx = buttonBar->fontNames->currentIndex();
     QString font = buttonBar->fontNames->itemText(idx);

--- a/src/gui/nbrowserwindow.cpp
+++ b/src/gui/nbrowserwindow.cpp
@@ -87,6 +87,10 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #endif
 
 
+#include <QUndoStack>
+#include <QVector>
+
+
 extern Global
         global;
 
@@ -226,6 +230,7 @@ NBrowserWindow::NBrowserWindow(QWidget *parent) :
     connect(editor, SIGNAL(htmlEditAlert()), this, SLOT(noteContentEdited()));
     connect(editor->page(), SIGNAL(linkClicked(QUrl)), this, SLOT(linkClicked(QUrl)));
     connect(editor->page(), SIGNAL(microFocusChanged()), this, SLOT(microFocusChanged()));
+    connect(editor->page(), SIGNAL(contentsChanged()), this, SLOT(correctFontTagAttr()));
 
     editor->page()->setLinkDelegationPolicy(QWebPage::DelegateAllLinks);
     connect(editor->page()->mainFrame(), SIGNAL(javaScriptWindowObjectCleared()), this, SLOT(exposeToJavascript()));
@@ -308,6 +313,7 @@ NBrowserWindow::NBrowserWindow(QWidget *parent) :
     if (css != "") {
         this->setStyleSheet(css);
     }
+
 }
 
 
@@ -887,6 +893,12 @@ void NBrowserWindow::saveNoteContent() {
 
 // The undo edit button was pressed
 void NBrowserWindow::undoButtonPressed() {
+    QUndoStack *stack = this->editor->page()->undoStack();
+    int index = stack->index();
+    if (autoBackspaceIndices.indexOf(index) != -1) {
+        // Called an additional undo in order that the the users do not have to press another undo button to remove the 0-width character "&zwnj;" added before.
+        this->editor->triggerPageAction(QWebPage::Undo);
+    }
     this->editor->triggerPageAction(QWebPage::Undo);
     this->editor->setFocus();
     microFocusChanged();
@@ -895,6 +907,13 @@ void NBrowserWindow::undoButtonPressed() {
 
 // The redo edit button was pressed
 void NBrowserWindow::redoButtonPressed() {
+    QUndoStack *stack = this->editor->page()->undoStack();
+    int index = stack->index();
+    // The font size changing operation index stored in autoBackspaceIndices is 2 ahead of backspace button event, so here add index to 2.
+    if (autoBackspaceIndices.indexOf(index + 2) != -1) {
+        // Called an additional redo in order that the the users do not have to press another redo button to restore the removed text content.
+        this->editor->triggerPageAction(QWebPage::Redo);
+    }
     this->editor->triggerPageAction(QWebPage::Redo);
     this->editor->setFocus();
     microFocusChanged();
@@ -1382,55 +1401,75 @@ void NBrowserWindow::fontSizeSelected(int index) {
         // Add an invisible charactor in order to set the cursor position
         // to the innerhtml part of the <span> tags added below. If not,
         // the text typed in after font size changed will be added beyond
-        // the <span> tags scope. This restricton is brought by
-        // document.execCommand called below.
+        // the <span> tags scope.
         text = "&zwnj;";
     }
 
     // Go througth the selected HTML and strip out all of the existing font-sizes.
     // This allows for the font size to be changed multiple times.  Without this the inner most font
     // size would always win.
-    for (int i = text.indexOf("<"); i >= 0; i = text.indexOf("<", i + 1)) {
-        QString text1 = "";
-        QString text2 = "";
-        text1 = text.mid(0, i);
-        QString interior = text.mid(i);
-        if (!interior.startsWith("</")) {
-            int endPos = text.indexOf(">", i);
-            if (endPos > 0) {
-                interior = text.mid(i, endPos - i);
-                text2 = text.mid(endPos);
-            }
-            // Now that we have a substring, look for the font-size
-            if (interior.contains("font-size:")) {
-                interior = interior.mid(0, interior.indexOf("font-size:")) +
-                           //QString::number(size)+
-                           interior.mid(interior.indexOf("pt;") + 3);
-                text = text1 + interior + text2;
-            }
-        }
-    }
+    //for (int i = text.indexOf("<"); i >= 0; i = text.indexOf("<", i + 1)) {
+    //    QString text1 = "";
+    //    QString text2 = "";
+    //    text1 = text.mid(0, i);
+    //    QString interior = text.mid(i);
+    //    if (!interior.startsWith("</")) {
+    //        int endPos = text.indexOf(">", i);
+    //        if (endPos > 0) {
+    //            interior = text.mid(i, endPos - i);
+    //            text2 = text.mid(endPos);
+    //        }
+    //        // Now that we have a substring, look for the font-size
+    //        if (interior.contains("font-size:")) {
+    //            interior = interior.mid(0, interior.indexOf("font-size:")) +
+    //                       //QString::number(size)+
+    //                       interior.mid(interior.indexOf("pt;") + 3);
+    //            text = text1 + interior + text2;
+    //        }
+    //    }
+    //}
 
     // Start building a new font span.
     int idx = buttonBar->fontNames->currentIndex();
     QString font = buttonBar->fontNames->itemText(idx);
 
-    QString newText =
-            "<span style=\"font-size:" + QString::number(size) + "pt;font-family:" + font + ";\">" + text + "</span>";
-    QString script = QString("document.execCommand('insertHtml', false, '" + newText + "');");
-    editor->page()->mainFrame()->evaluateJavaScript(script);
-
-    editor->setFocus();
-    microFocusChanged();
-
     if (text == "&zwnj;") {
+        QString newText = "<span style=\"font-size:" + QString::number(size) +"pt;font-family:" + font + ";\">" + text + "</span>";
+        QString script2 = QString("document.execCommand('insertHtml', false, '" + newText + "');");
+        editor->page()->mainFrame()->evaluateJavaScript(script2);
+
         // Simulate a backspace press down event to delete
         // the invisible charactor inserted above.
         QKeyEvent *key_press = new QKeyEvent(QKeyEvent::KeyPress,
                 Qt::Key_Backspace, Qt::NoModifier, "");
         QApplication::sendEvent(editor, key_press);
         delete key_press;
+
+        QUndoStack *stack = this->editor->page()->undoStack();
+        int index = stack->index();
+        autoBackspaceIndices.append(index);
+
+    } else {
+    
+        QString script = QString("document.execCommand('fontSize', false, 5);");
+        editor->page()->mainFrame()->evaluateJavaScript(script);
+
+        // document.execCommand fontSize will generate font tag with size attribute set,
+        // which may make the following font setting out of order. So replace it with
+        // css style here.
+        QString js = QString("var nodes = document.getElementsByTagName(\"font\");") +
+                     QString("for (var i = 0; i < nodes.length; i++) {") +
+                     QString("    if (nodes[i].attributes[\"size\"] != null) {") +
+                     QString("        nodes[i].removeAttribute(\"size\");") +
+                     QString("        nodes[i].setAttribute(\"style\", \"font-size:" + QString::number(size) + "pt;\");") +
+                     QString("    }") +
+                     QString("}");
+                     
+        editor->page()->mainFrame()->evaluateJavaScript(js);
     }
+
+    editor->setFocus();
+    microFocusChanged();
 }
 
 
@@ -2057,6 +2096,28 @@ void NBrowserWindow::microFocusChanged() {
     saveTimer.start();
 }
 
+
+// When a font size is selected, and the page content is empty, any keyboard input
+// will make font tag generated with size attribute set, which may make the following
+// font size setting out of order. So have to replace it with css style. Called only when the content is null.
+void NBrowserWindow::correctFontTagAttr() {
+    // Only modify the attribute when no content selected, so that the note content is null belongs to this case.
+    if (this->editor->selectedHtml() != "") {
+        return;
+    }
+
+    int size = buttonBar->fontSizes->currentText().toInt();
+    QString js = QString("var nodes = document.getElementsByTagName(\"font\");") +
+                 QString("for (var i = 0; i < nodes.length; i++) {") +
+             QString("    if (nodes[i].attributes[\"size\"] != null) {") +
+             QString("        nodes[i].removeAttribute(\"size\");") +
+             QString("        nodes[i].setAttribute(\"style\", \"font-size:" + QString::number(size) + "pt;\");") +
+             QString("    }") +
+             QString("}");
+
+    editor->page()->mainFrame()->evaluateJavaScript(js);
+}
+
 void NBrowserWindow::printNodeName(QString v) {
     QLOG_DEBUG() << v;
 }
@@ -2346,6 +2407,8 @@ void NBrowserWindow::clear() {
 //    editor->page()->setContentEditable(false);
 
     dateEditor.clear();
+
+    autoBackspaceIndices.clear();
 }
 
 
@@ -3842,18 +3905,18 @@ void NBrowserWindow::noteContentEdited() {
 
 
 void NBrowserWindow::changeDisplayFontSize(QString size) {
-    bool convert = true;
+    bool convert = false;
     if (size.endsWith("px", Qt::CaseInsensitive))
         convert = true;
     size.chop(2);  // Remove px from the end
-    int converted = size.toInt();
+    float converted = size.toFloat();
     if (convert) {
         PixelConverter c;
         converted = c.getPoints(converted);
-        size = QString::number(converted);
+        size = QString::number(int(converted));
     }
     int idx = buttonBar->fontSizes->findData(size, Qt::UserRole);
-    if (idx > 0) {
+    if (idx >= 0) {
         buttonBar->fontSizes->blockSignals(true);
         buttonBar->fontSizes->setCurrentIndex(idx);
         buttonBar->fontSizes->blockSignals(false);

--- a/src/gui/nbrowserwindow.cpp
+++ b/src/gui/nbrowserwindow.cpp
@@ -314,6 +314,7 @@ NBrowserWindow::NBrowserWindow(QWidget *parent) :
         this->setStyleSheet(css);
     }
 
+    changeDisplayFontName(global.defaultFont);
 }
 
 
@@ -1470,6 +1471,7 @@ void NBrowserWindow::fontSizeSelected(int index) {
 
     editor->setFocus();
     microFocusChanged();
+    buttonBar->fontSizes->setCurrentText(QString::number(size));
 }
 
 

--- a/src/gui/nbrowserwindow.cpp
+++ b/src/gui/nbrowserwindow.cpp
@@ -1434,15 +1434,7 @@ void NBrowserWindow::fontSizeSelected(int index) {
         // document.execCommand fontSize will generate font tag with size attribute set,
         // which may make the following font setting out of order. So replace it with
         // css style here.
-        QString js = QString("var nodes = document.getElementsByTagName(\"font\");") +
-                     QString("for (var i = 0; i < nodes.length; i++) {") +
-                     QString("    if (nodes[i].attributes[\"size\"] != null) {") +
-                     QString("        nodes[i].removeAttribute(\"size\");") +
-                     QString("        nodes[i].setAttribute(\"style\", \"font-size:" + QString::number(size) + "pt;\");") +
-                     QString("    }") +
-                     QString("}");
-                     
-        editor->page()->mainFrame()->evaluateJavaScript(js);
+        modifyFontTagAttr(size);
     }
 
     editor->setFocus();
@@ -2075,6 +2067,18 @@ void NBrowserWindow::microFocusChanged() {
 }
 
 
+void NBrowserWindow::modifyFontTagAttr(int size) {
+    QString js = QString("var nodes = document.getElementsByTagName(\"font\");") +
+                 QString("for (var i = 0; i < nodes.length; i++) {") +
+             QString("    if (nodes[i].attributes[\"size\"] != null) {") +
+             QString("        nodes[i].removeAttribute(\"size\");") +
+             QString("        nodes[i].setAttribute(\"style\", \"font-size:" + QString::number(size) + "pt;\");") +
+             QString("    }") +
+             QString("}");
+
+    editor->page()->mainFrame()->evaluateJavaScript(js);
+}
+
 // When a font size is selected, and the page content is empty, any keyboard input
 // will make font tag generated with size attribute set, which may make the following
 // font size setting out of order. So have to replace it with css style. Called only when the content is null.
@@ -2085,15 +2089,10 @@ void NBrowserWindow::correctFontTagAttr() {
     }
 
     int size = buttonBar->fontSizes->currentText().toInt();
-    QString js = QString("var nodes = document.getElementsByTagName(\"font\");") +
-                 QString("for (var i = 0; i < nodes.length; i++) {") +
-             QString("    if (nodes[i].attributes[\"size\"] != null) {") +
-             QString("        nodes[i].removeAttribute(\"size\");") +
-             QString("        nodes[i].setAttribute(\"style\", \"font-size:" + QString::number(size) + "pt;\");") +
-             QString("    }") +
-             QString("}");
+    if (size <= 0)
+        return;
 
-    editor->page()->mainFrame()->evaluateJavaScript(js);
+    modifyFontTagAttr(size);
 }
 
 void NBrowserWindow::printNodeName(QString v) {

--- a/src/gui/nbrowserwindow.h
+++ b/src/gui/nbrowserwindow.h
@@ -110,6 +110,7 @@ private:
     void saveSpellCheckerLocaleToSettings(QString locale);
     void spellCheckAddWordToUserDictionary(QString currentWord);
 
+    void modifyFontTagAttr(int size);
 
     // Shortcuts for context menu
     QShortcut *attachFileShortcut;

--- a/src/gui/nbrowserwindow.h
+++ b/src/gui/nbrowserwindow.h
@@ -130,6 +130,10 @@ private:
     QString tableStyle;
     QPoint scrollPoint;
 
+    // To record the simulated backspace button events in the undoStack.
+    QVector<int> autoBackspaceIndices;
+
+
     void exitPoint(ExitPoint *exit);
 
     // get note title from the title UI field - and do some fixup (like discard line feeds)
@@ -363,7 +367,7 @@ private slots:
     void saveTimeCheck();
     void browserThreadStarted();
     void repositionAfterSourceEdit(bool);
-
+    void correctFontTagAttr();
 };
 
 

--- a/src/gui/ntableview.cpp
+++ b/src/gui/ntableview.cpp
@@ -718,6 +718,12 @@ void NTableView::deleteSelectedNotes() {
     }
     //transaction.exec("commit");
     sql.finish();
+
+    // Unpin the note being deleted, so that the table view
+    // will not display a pinned note even after it
+    // has been deleted.
+    unpinNote();
+
     emit(notesDeleted(lids, expunged));
 }
 

--- a/src/gui/ntableview.cpp
+++ b/src/gui/ntableview.cpp
@@ -78,7 +78,15 @@ NTableView::NTableView(QWidget *parent) :
     //refreshData();
     setModel(proxy);
     // disable user sorting
-    this->setSortingEnabled(false);
+    //this->setSortingEnabled(false);
+    global.settings->beginGroup("SaveState");
+    Qt::SortOrder order = Qt::SortOrder(global.settings->value("sortOrder", 0).toInt());
+    int col = global.settings->value("sortColumn", NOTE_TABLE_DATE_CREATED_POSITION).toInt();
+    global.settings->endGroup();
+    this->setSortingEnabled(true);
+    proxy->setFilterKeyColumn(NOTE_TABLE_LID_POSITION);
+    sortByColumn(col, order);
+    noteModel->sort(col,order);
 
     // Set the date delegates
     QLOG_TRACE() << "Setting up table delegates";

--- a/src/gui/ntableview.cpp
+++ b/src/gui/ntableview.cpp
@@ -77,8 +77,7 @@ NTableView::NTableView(QWidget *parent) :
 
     //refreshData();
     setModel(proxy);
-    // disable user sorting
-    //this->setSortingEnabled(false);
+
     global.settings->beginGroup("SaveState");
     Qt::SortOrder order = Qt::SortOrder(global.settings->value("sortOrder", 0).toInt());
     int col = global.settings->value("sortColumn", NOTE_TABLE_DATE_CREATED_POSITION).toInt();

--- a/src/nixnote.cpp
+++ b/src/nixnote.cpp
@@ -2106,7 +2106,7 @@ void NixNote::restoreAndNewNote() {
 
 #define NEW_NOTE_ENML "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" \
                       "<!DOCTYPE en-note SYSTEM \"http://xml.evernote.com/pub/enml2.dtd\">" \
-                      "<en-note ><br/><br/><br/></en-note>"
+                      "<en-note style=\"word-wrap: break-word; -webkit-nbsp-mode: space; -webkit-line-break: after-white-space;\"></en-note>"
 
 /**
  * Create a new note

--- a/src/nixnote.cpp
+++ b/src/nixnote.cpp
@@ -93,6 +93,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #include "src/qevercloud/QEverCloud/headers/QEverCloud.h"
 #include "src/qevercloud/QEverCloud/headers/QEverCloudOAuth.h"
 
+
 using namespace qevercloud;
 
 // Windows Check
@@ -1698,8 +1699,13 @@ void NixNote::updateSelectionCriteria(bool afterSync) {
         global.cache.remove(keys[i]);
     }
 
+    // The filter() function can work without being passed parameters, but
+    // it is best to allocate a QList<qint32> object for filter() here
+    // in case that filter() returns result via it in the future.
     FilterEngine filterEngine;
-    filterEngine.filter();
+    QList<qint32> *results = new QList<qint32>();
+    filterEngine.filter(NULL, results);
+    delete results;
 
     QLOG_DEBUG() << "Refreshing data";
     noteTableView->refreshData();

--- a/src/nixnote.cpp
+++ b/src/nixnote.cpp
@@ -3278,6 +3278,10 @@ void NixNote::deleteCurrentNote() {
     QList<qint32> lids;
     lids.append(lid);
     emit(notesDeleted(lids));
+    // Unpin the note being deleted, so that the table view
+    // will not display a pinned note even after it
+    // has been deleted.
+    unpinCurrentNote();
 }
 
 

--- a/src/utilities/pixelconverter.cpp
+++ b/src/utilities/pixelconverter.cpp
@@ -19,7 +19,6 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 
 #include "pixelconverter.h"
-#include <iostream>
 
 PixelConverter::PixelConverter()
 {

--- a/src/utilities/pixelconverter.cpp
+++ b/src/utilities/pixelconverter.cpp
@@ -19,6 +19,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 
 #include "pixelconverter.h"
+#include <iostream>
 
 PixelConverter::PixelConverter()
 {
@@ -53,10 +54,10 @@ PixelConverter::PixelConverter()
 }
 
 
-int PixelConverter::getPoints(int px) {
+int PixelConverter::getPoints(float px) {
     if (px <=0)
         return -1;
-    if (pointArray.contains(px))
-        return pointArray[px];
-    return px*3/4;
+    //if (pointArray.contains(int(px + 0.5)))
+    //    return pointArray[int(px + 0.5)];
+    return int(px*3.0f/4.0f + 0.5);
 }

--- a/src/utilities/pixelconverter.h
+++ b/src/utilities/pixelconverter.h
@@ -28,7 +28,7 @@ private:
     QHash<int,int> pointArray;
 public:
     PixelConverter();
-    int getPoints(int px);
+    int getPoints(float px);
 };
 
 #endif // PIXELCONVERTER_H


### PR DESCRIPTION
The original issue link is https://github.com/robert7/nixnote2/issues/156 and https://github.com/robert7/nixnote2/issues/149.

The font size can be changed in most of the time, but not always. When the font size is set to some specific value such as 10pt, it may become the start of problems. This issue is caused by the html tag auto completion of QWebview. QWebview intends to complete the html tags for the users, but it may make troubles sometimes. After selecting font size as 10pt, and removing the text, when input a character again, QWebview will add a font tag with 'size' attribute set, but it cannot deal with this attribute correctly if the users change the font size again. I just replaced the 'size' attribute with 'font-size' attribute with JS.

This issue can be reproduced like this (it may be a little tedious if I describe it in text, so I upload several pictures):

![issue156_text](https://user-images.githubusercontent.com/105552832/175868986-6512603f-e25c-4930-9baa-f44745f16687.gif)

And there are problems when changing the font size in blockquote, unordered list, table, etc, it will break the original format.

![issue156_bq](https://user-images.githubusercontent.com/105552832/175869368-4c77c016-06c3-403d-aabe-97bb2955527e.gif)

![issue156_list](https://user-images.githubusercontent.com/105552832/175869381-33eed5bd-7c60-4b80-bcd1-af1319898ccf.gif)

After fixing it, it is like:

![issue156_fixed_text](https://user-images.githubusercontent.com/105552832/175871208-9df56ee5-0011-4209-814a-7b720b27adec.gif)

![issue156_fixed_bq](https://user-images.githubusercontent.com/105552832/175869553-584f2d3f-48fd-474d-a07d-770a7ae45a54.gif)

![issue156_fixed_list](https://user-images.githubusercontent.com/105552832/175869502-7a7e7c0e-2599-40c1-8749-4939773cffe8.gif)

In addition to this issue, I also added a functionality that the font size can be changed when no text is selected.

As to the sort function, I copied the sort code from the original code repository. This may be useful for some users.

And I added the word-wrap attribute to the note template. Without it, the horizontal scrollbar will appear when the line exceeds the editor width. I noticed that it was removed by someone. If you know the reason, please tell me.

Issue 149 is caused by the sqlite datetime function not executed correctly. Actually there is no need to call it when comparing two datetime variable values, so I just removed it and compared the seconds since epoch directly, and it works fine now.