### PR TITLE
Fixed the issue: Nixnote2 exits when network gets disconnected #189

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,4 +1,5 @@
 NixNote (2.1.7) stable; urgency=low
+  * Fixed: Nixnote2 exits when network gets disconnected - issue #189
   * Fixed: Import all notes, tag issue - issue #153
   * Fixed: Local images cannot be pasted, web image's html element cannot be saved
   * Fixed: Search by date attributes not working with PPA builds - issue #149

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,5 @@
 NixNote (2.1.7) stable; urgency=low
+  * Fixed: Nixnote2 exits when network gets disconnected - issue #189
   * Fixed: Import all notes, tag issue - issue #153
   * Fixed: Local images cannot be pasted, web image's html element cannot be saved
   * Fixed: Search by date attributes not working with PPA builds - issue #149

--- a/src/gui/browserWidgets/editorbuttonbar.cpp
+++ b/src/gui/browserWidgets/editorbuttonbar.cpp
@@ -830,7 +830,7 @@ void EditorButtonBar::loadFontNames() {
 void EditorButtonBar::loadFontSizeComboBox(QString name) {
     QFontDatabase fdb;
     fontSizes->clear();
-    QList<int> sizes = fdb.smoothSizes(name, "Normal");
+    QList<int> sizes = fdb.pointSizes(name);
     for (int i = 0; i < sizes.size(); i++) {
         fontSizes->addItem(QString::number(sizes[i]), sizes[i]);
     }

--- a/src/gui/nbrowserwindow.cpp
+++ b/src/gui/nbrowserwindow.cpp
@@ -406,7 +406,7 @@ void NBrowserWindow::setupToolBar() {
     connect(buttonBar->spellCheckButtonAction, SIGNAL(triggered()), this, SLOT(spellCheckPressed()));
     connect(buttonBar->spellCheckButtonShortcut, SIGNAL(activated()), this, SLOT(spellCheckPressed()));
 
-    connect(buttonBar->fontSizes, SIGNAL(currentIndexChanged(int)), this, SLOT(fontSizeSelected(int)));
+    connect(buttonBar->fontSizes, SIGNAL(activated(int)), this, SLOT(fontSizeSelected(int)));
     connect(buttonBar->fontNames, SIGNAL(currentIndexChanged(int)), this, SLOT(fontNameSelected(int)));
 
     connect(buttonBar->fontColorButtonWidget, SIGNAL(clicked()), this, SLOT(fontColorClicked()));
@@ -1414,6 +1414,10 @@ void NBrowserWindow::todoButtonPressed() {
 // The font size button was pressed
 void NBrowserWindow::fontSizeSelected(int index) {
     int size = buttonBar->fontSizes->itemData(index).toInt();
+
+    if (this->editor->selectedText() == "" && buttonBar->fontSizes->currentText() == QString(size)) {
+        return;
+    }
 
     if (size <= 0)
         return;

--- a/src/nixnote.cpp
+++ b/src/nixnote.cpp
@@ -2021,7 +2021,7 @@ void NixNote::notifySyncComplete() {
                  << ", popupOnSyncError=" << popupOnSyncError
                  << ", syncNotifications=" << syncNotifications;
 
-    if (haveSyncError && popupOnSyncError) {
+    if (haveSyncError && popupOnSyncError && !this->isHidden()) {
         QMessageBox::critical(this, tr("Sync Error"), tr("Sync error. See message log for details"));
         return;
     }


### PR DESCRIPTION
The reason of issue #189 is:
Nixnote will show a dialog when sync error happens. When closing the dialog, the whole application will exit. This is a Qt feature.

To fix this issue, I made the sync error dialog not show when the main window is minimized to the system tray. Instead, Nixnote will pop up sync error from the tray icon now.

Besides that, I did some improvements about font size setting.

In EditorButtonBar::loadFontSizeComboBox(), I replaced smoothSizes() with pointSizes(), because AppearancePreferences::loadFontSizes() uses this function to load font sizes too. And smoothSizes() and pointSizes() always return different results when the same font is passed in to them. Because of this, the font size lists in the editor and preference dialog differed previously.

And I also made a supplyment to pr #187. That is, I made the fontSizeSelected() be called even when the value in the combobox has no change, through connecting the activated signal instead of currentIndexChanged signal from buttonBar->fontSizes, with slot function fontSizeSelected(). This is useful when texts in different sizes are selected and the user intends to resize them to the current font size in the combobox.