### PR TITLE
Fixed: windows edition find results background color, recently updated menu width, memory leaks, and font size unconsistence

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,4 +1,8 @@
 NixNote (2.1.7) stable; urgency=low
+  * Made the font size in the setting dialog consistent with the one in the editor button bar.
+  * Made the Windows editon's results of find more recognizable.
+  * Limited the max length of the recently updated menu of the tray.
+  * Fixed memory leaks caused by Qt Webview.
   * Fixed: To-do Formatting is not in parity with Official Client - issue #131
   * Fixed: In-App Note links don't work when there is an apostrophe in the title - issue #168
   * Fixed: Nixnote2 exits when network gets disconnected - issue #189

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,8 @@
 NixNote (2.1.7) stable; urgency=low
+  * Made the font size in the setting dialog consistent with the one in the editor button bar.
+  * Made the Windows editon's results of find more recognizable.
+  * Limited the max length of the recently updated menu of the tray.
+  * Fixed memory leaks caused by Qt Webview.
   * Fixed: To-do Formatting is not in parity with Official Client - issue #131
   * Fixed: In-App Note links don't work when there is an apostrophe in the title - issue #168
   * Fixed: Nixnote2 exits when network gets disconnected - issue #189

--- a/resources/images/checkbox.css
+++ b/resources/images/checkbox.css
@@ -1,5 +1,5 @@
 img.todo-icon {
-    vertical-align: text-bottom !important;
+    vertical-align: baseline !important;
     cursor: pointer;
     padding-right: 5px;
 
@@ -7,6 +7,4 @@ img.todo-icon {
     -webkit-user-drag: none;
 }
 
-font > img.todo-icon, span > img.todo-icon {
-    vertical-align: baseline !important;
-}
+

--- a/src/dialog/preferences/appearancepreferences.cpp
+++ b/src/dialog/preferences/appearancepreferences.cpp
@@ -297,7 +297,9 @@ void AppearancePreferences::saveValues() {
         // QWebkit DPI is hard coded to 96. Hence, we calculate the correct
         // font size based on desktop logical DPI.
         if (global.defaultFontSize > 0) {
-            settings->setFontSize(QWebSettings::DefaultFontSize, global.defaultFontSize * (QApplication::desktop()->logicalDpiX() / 96.0));
+            settings->setFontSize(QWebSettings::DefaultFontSize,
+                    (4.0/3.0) * global.defaultFontSize *
+                    (QApplication::desktop()->logicalDpiX() / 96.0));
         }
     }
 

--- a/src/global.cpp
+++ b/src/global.cpp
@@ -173,7 +173,8 @@ void Global::setup(StartupConfig startupConfig, bool guiAvailable) {
         // QWebkit DPI is hard coded to 96. Hence, we calculate the correct
         // font size based on desktop logical DPI.
         settings->setFontSize(QWebSettings::DefaultFontSize,
-                              defaultFontSize * (QApplication::desktop()->logicalDpiX() / 96.0)
+                              (4.0/3.0) * defaultFontSize *
+                              (QApplication::desktop()->logicalDpiX() / 96.0)
         );
     }
     if (defaultFont != "" && defaultFontSize <= 0 && this->guiAvailable) {

--- a/src/gui/nbrowserwindow.cpp
+++ b/src/gui/nbrowserwindow.cpp
@@ -240,9 +240,6 @@ NBrowserWindow::NBrowserWindow(QWidget *parent) :
     factory = new PluginFactory(this);
     editor->page()->setPluginFactory(factory);
 
-    editor->page()->settings()->setUserStyleSheetUrl(
-            QUrl::fromLocalFile(QDir::toNativeSeparators(global.fileManager.getImageDirPath("") + QString("/checkbox.css"))));
-
     buttonBar->getButtonbarState();
 
     printPage = new QTextEdit();
@@ -4110,6 +4107,17 @@ QString base64_encode(QString string) {
 // Set the editor background & font color
 void NBrowserWindow::setEditorStyle() {
     QString css = global.getEditorCss();
+
+    QString path = global.fileManager.getImageDirPath("") +
+        QString("checkbox.css");
+    path.replace("file:///", "").replace("file://", "");
+    QFile f(QDir::toNativeSeparators(path));
+    f.open(QFile::ReadOnly);
+    QTextStream in(&f);
+    QString checkbox = in.readAll();
+    f.close();
+    css += checkbox;
+
     if (css.isEmpty()) {
         return;
     }

--- a/src/gui/nbrowserwindow.cpp
+++ b/src/gui/nbrowserwindow.cpp
@@ -318,6 +318,7 @@ NBrowserWindow::NBrowserWindow(QWidget *parent) :
     }
 
     changeDisplayFontName(global.defaultFont);
+    changeDisplayFontSize(QString::number(global.defaultFontSize) + "pt");
 }
 
 

--- a/src/gui/nbrowserwindow.cpp
+++ b/src/gui/nbrowserwindow.cpp
@@ -556,6 +556,14 @@ void NBrowserWindow::setContent(qint32 lid) {
     //**** END OF CALL TO PRE-LOAD EXIT
 
     editor->setContent(content);
+
+    // Qt Webview memory leaks solution:
+    // https://forum.qt.io/topic/10832/memory-size-increases-per-page-load/4
+    QWebElement body = editor->page()->mainFrame()->findFirstElement("body");
+    body.setAttribute("onunload", "_function() {}");
+    QWebSettings::clearMemoryCaches();
+    editor->history()->clear();
+
     // is this an ink note?
     if (inkNote)
         editor->page()->setContentEditable(false);

--- a/src/gui/nbrowserwindow.cpp
+++ b/src/gui/nbrowserwindow.cpp
@@ -1464,28 +1464,26 @@ void NBrowserWindow::todoSetAllChecked(bool allSelected) {
 // The font size button was pressed
 void NBrowserWindow::fontSizeSelected(int index) {
     int size = buttonBar->fontSizes->itemData(index).toInt();
-
-    if (this->editor->selectedText() == "" && buttonBar->fontSizes->currentText() == QString(size)) {
-        return;
-    }
-
     if (size <= 0)
         return;
 
-    QString text = editor->selectedHtml();
-    if (text.trimmed() == "") {
-        // Add an invisible charactor in order to set the cursor position
-        // to the innerhtml part of the <span> tags added below. If not,
-        // the text typed in after font size changed will be added beyond
-        // the <span> tags scope.
-        text = "&zwnj;";
+    if (this->editor->selectedText() == "" &&
+            buttonBar->fontSizes->currentText() == QString(size)) {
+        return;
     }
 
     // Start building a new font span.
     int idx = buttonBar->fontNames->currentIndex();
     QString font = buttonBar->fontNames->itemText(idx);
 
-    if (text == "&zwnj;") {
+    QString text = editor->selectedHtml();
+    if (text.trimmed() == "") {
+        // Add an invisible charactor in order to focus on the innerhtml
+        // part of the <span> tags added below. If not, the text typed
+        // in after font size changed will be added beyond the <span>
+        // tags scope.
+        text = "&zwnj;";
+
         QString newText = "<span style=\"font-size:" + QString::number(size) +"pt;font-family:" + font + ";\">" + text + "</span>";
         QString script2 = QString("document.execCommand('insertHtml', false, '" + newText + "');");
         editor->page()->mainFrame()->evaluateJavaScript(script2);
@@ -1503,9 +1501,9 @@ void NBrowserWindow::fontSizeSelected(int index) {
         QString script = QString("document.execCommand('fontSize', false, 5);");
         editor->page()->mainFrame()->evaluateJavaScript(script);
 
-        // document.execCommand fontSize will generate font tag with size attribute set,
-        // which may make the following font setting out of order. So replace it with
-        // css style here.
+        // document.execCommand fontSize will generate font tag with 'size'
+        // attribute set, which now and then makes the following font size
+        // setting in trouble. So replace it with 'font-size' here.
         modifyFontTagAttr(size);
     }
 

--- a/src/gui/nbrowserwindow.cpp
+++ b/src/gui/nbrowserwindow.cpp
@@ -1415,16 +1415,10 @@ void NBrowserWindow::todoButtonPressed() {
     QRegExp regex("\\r?\\n");
     QStringList items = selectedText.split(regex);
 
-    // Add a font element to set vertical-align:middle attribute
-    // in the css file for the text in the todo item.
-    QString font = buttonBar->fontNames->currentText();
-    QString fontSize = buttonBar->fontSizes->currentText();
-    QString fontElement = QString("<font style=\"font-size:") +
-        fontSize + "pt;\"" + QString(" face=\"") + font + QString(";\">");
-
     QString html = "";
     for (int i = 0; i < items.size(); i++) {
-        html += "<div>" + global.getCheckboxElement(false, true) +items[i] + "</div>";
+        html += "<div>" + global.getCheckboxElement(false, true) + items[i] +
+            "</div>";
     }
 
     editor->page()->mainFrame()->evaluateJavaScript(script_start + html + script_end);

--- a/src/gui/nbrowserwindow.cpp
+++ b/src/gui/nbrowserwindow.cpp
@@ -4258,11 +4258,7 @@ void NBrowserWindow::findShortcut() {
 //* in a note.
 //*******************************************
 void NBrowserWindow::findNextShortcut() {
-    findReplace->showFind();
-    QString find = findReplace->findLine->text();
-    if (find != "")
-        editor->page()->findText(find,
-                                 findReplace->getCaseSensitive() | QWebPage::FindWrapsAroundDocument);
+    this->findNextInNote();
 }
 
 
@@ -4271,12 +4267,7 @@ void NBrowserWindow::findNextShortcut() {
 //* text in a note.
 //*******************************************
 void NBrowserWindow::findPrevShortcut() {
-    findReplace->showFind();
-    QString find = findReplace->findLine->text();
-    if (find != "")
-        editor->page()->findText(find,
-                                 findReplace->getCaseSensitive() | QWebPage::FindBackward |
-                                 QWebPage::FindWrapsAroundDocument);
+    this->findPrevInNote();
 }
 
 
@@ -4337,6 +4328,14 @@ void NBrowserWindow::findNextInNote() {
     if (find != "")
         editor->page()->findText(find,
                                  findReplace->getCaseSensitive() | QWebPage::FindWrapsAroundDocument);
+    // The background color of the occurances
+    // when finding text under Windows is
+    // light gray, not recognizable enough,
+    // for better experience, add a background
+    // color for them here.
+#ifdef _WIN32
+    editor->page()->findText(find, QWebPage::HighlightAllOccurrences);
+#endif
 }
 
 
@@ -4352,6 +4351,9 @@ void NBrowserWindow::findPrevInNote() {
                                  findReplace->getCaseSensitive() | QWebPage::FindBackward |
                                  QWebPage::FindWrapsAroundDocument);
 
+#ifdef _WIN32
+    editor->page()->findText(find, QWebPage::HighlightAllOccurrences);
+#endif
 }
 
 

--- a/src/gui/ntableview.cpp
+++ b/src/gui/ntableview.cpp
@@ -613,11 +613,20 @@ void NTableView::mouseReleaseEvent(QMouseEvent *e) {
 // Listen for up & down arrows
 void NTableView::keyPressEvent(QKeyEvent *event) {
     QTableView::keyPressEvent(event);
-    if (event->key() == Qt::Key_Up || event->key() == Qt::Key_Down ||
-        event->key() == Qt::Key_PageUp || event->key() == Qt::Key_PageDown)
+    if (event->key() == Qt::Key_PageUp || event->key() == Qt::Key_PageDown)
         this->openSelectedLids(false);
-
 }
+
+void NTableView::keyReleaseEvent(QKeyEvent *event) {
+    if (event->isAutoRepeat()) {
+        return;
+    }
+    QTableView::keyReleaseEvent(event);
+    if (event->key() == Qt::Key_Up || event->key() == Qt::Key_Down) {
+        this->openSelectedLids(false);
+    }
+}
+
 
 
 // Open a selected note.  This is not done via the context menu.

--- a/src/gui/ntableview.h
+++ b/src/gui/ntableview.h
@@ -62,6 +62,7 @@ public:
     void openSelectedLids(bool newWindow);
     void refreshSelection();
     void keyPressEvent(QKeyEvent *event);
+    void keyReleaseEvent(QKeyEvent *event);
 
     QMenu *contextMenu;
     QMenu *colorMenu;

--- a/src/gui/traymenu.cpp
+++ b/src/gui/traymenu.cpp
@@ -81,6 +81,12 @@ void TrayMenu::buildActionMenu() {
     if (recentlyUpdatedMenu) {
         records.clear();;
         noteTable.getRecentlyUpdated(records);
+        const int MAX_LENGTH = 30;
+        for (int i = 0; i < records.length(); i++) {
+            if (records[i].second.length() > MAX_LENGTH) {
+                records[i].second = records[i].second.left(MAX_LENGTH) + "...";
+            }
+        }
         buildMenu("recentlyUpdatedMenu", recentlyUpdatedMenu, records);
     }
 

--- a/testsrc/tests.cpp
+++ b/testsrc/tests.cpp
@@ -201,7 +201,7 @@ void Tests::enmlNixnoteLinkTest() {
         QString src(
                 R"R(<a en-tag="en-media" lid="45878" type="application/vnd.oasis.opendocument.spreadsheet" hash="2bb10cc981690fc6b87e50b825667bbb" href="nnres:/home/robert7/.nixnote/db-2/dba/45878.ods" oncontextmenu="window.browserWindow.resourceContextMenu(&amp;apos/home/robert7/.nixnote/db-2/dba/45878.ods&amp;apos);"><img en-tag="temporary" title="qs-qs.ods" src="file:///&lt;img en-tag=" temporary"=""></a><br><a type="application/zip" hash="eb57834ba58527ea4d4422f7fbf4498c" href="nnres:/home/robert7/.nixnote/db-2/dba/45880.zip" oncontextmenu="window.browserWindow.resourceContextMenu('/home/robert7/.nixnote/tmp-2/45880------.zip');" en-tag="en-media" lid="45880" title="nnres:/home/robert7/.nixnote/db-2/dba/45880.zip"><img src="file:////home/robert7/.nixnote/tmp-2/45880_icon.png" title="shortcuts.zip" en-tag="temporary"></a>)R");
         QString result(
-                R"R(<en-media type="application/vnd.oasis.opendocument.spreadsheet" hash="2bb10cc981690fc6b87e50b825667bbb"/><br><en-media type="application/zip" hash="eb57834ba58527ea4d4422f7fbf4498c"/>)R");
+                R"R(<en-media type="application/vnd.oasis.opendocument.spreadsheet" hash="2bb10cc981690fc6b87e50b825667bbb"/><br /><en-media type="application/zip" hash="eb57834ba58527ea4d4422f7fbf4498c"/>)R");
 
         const QString r1 = formatToEnml(src);
         const QString r2 = addEnmlEnvelope(result, QStringLiteral("45878,45880"));
@@ -243,7 +243,7 @@ void Tests::enmlNixnoteLinkTest() {
         result.append(R"R("href=")R");
         result.append(resourceUrl);
         result.append(
-                R"R("><en-media type="image/gif" hash="69cb83339ee2fb3f008492f82f98cbbc"/></a><br>)R");
+                R"R("><en-media type="image/gif" hash="69cb83339ee2fb3f008492f82f98cbbc"/></a><br />)R");
         const QString r1 = formatToEnml(src);
         const QString r2 = addEnmlEnvelope(result, "45913");
         QCOMPAREX(r1, r2); // note: use string, not expressions
@@ -267,7 +267,7 @@ void Tests::enmlNixnoteObjectTest() {
         QString src(
                 R"R(<div><object style="width:100%; height: 600px" hash="817602cc08f9237ed641ed1703784eca" type="application/pdf" lid="45883"></object><br></div>)R");
         QString result(
-                R"R(<div><en-media type="application/pdf" hash="817602cc08f9237ed641ed1703784eca"/><br></div>)R");
+                R"R(<div><en-media type="application/pdf" hash="817602cc08f9237ed641ed1703784eca"/><br /></div>)R");
         QCOMPARE(formatToEnml(src), addEnmlEnvelope(result, QStringLiteral("45883")));
     }
 }
@@ -301,7 +301,7 @@ void Tests::enmlNixnoteTableTest() {
             R"R(<div><table border="1" width="100%" class="abcd"> <tbody> <tr> <td><br> aa  aaa</td> </tr></tbody></table></div>)R"
     );
     QString result(
-            R"R(<div><table border="1" width="100%"><tbody><tr><td><br>aa aaa</td></tr></tbody></table></div>)R");
+            R"R(<div><table border="1" width="100%"><tbody><tr><td><br />aa aaa</td></tr></tbody></table></div>)R");
     QCOMPARE(formatToEnml(src), addEnmlEnvelope(result));
 }
 


### PR DESCRIPTION
Highlight all results of find for the Windows edition, just as Qt Creator does. Under Windows, the results of find have a light grey background, which is very uncognizable.

Limit the max length of the recently updated menu of the tray. Otherwise, when the titles are too long, the menu will occupy the whole screen.

Fix memory leaks caused by Qt Webview. Nixnote ram usage was always increasing, seldom decreasing.

Convert the font size value to pixels when calling QWebSettings::setFontSize() in appearancepreferences.cpp and global.cpp. As in the function of setFontSize, the unit of measurement of font size parameter is pixel, which differs with the one of the editor font size combobox whose unit is points, so we have to make a conversion.

And moved the code of setting checkbox style from NBrowserWindow constructer function to setEditorStyle(), in order that subsequent setting will not overwrite the former one.

Make the editor not render the note content when Key_Up or Key_Down is kept being pressed, in order to reduce the needless rendering, which increases the cpu usage and freeze the UI when passing by large notes.

