### PR TITLE
Fix the issue: regression introduced in sorting code (pull #187) - narrow note list no longer sorted 

### DIFF
--- a/src/gui/nmainmenubar.cpp
+++ b/src/gui/nmainmenubar.cpp
@@ -645,6 +645,7 @@ void NMainMenuBar::onSortMenuTriggered() {
     QString data = pAction->data().toString();
     QLOG_DEBUG() << "sort action data= " << data;
     global.setSortOrder(data);
+    parent->resetNoteTableSortColumn();
 
     // refresh result set
     parent->updateSelectionCriteria(false);

--- a/src/models/notemodel.cpp
+++ b/src/models/notemodel.cpp
@@ -60,6 +60,7 @@ NoteModel::NoteModel(QObject *parent)
 QString NoteModel::orderByClause() const {
     QString order("order by " + global.getSortOrder());
     QLOG_DEBUG() << "Sort order: " << order;
+
     return order;
 }
 

--- a/src/models/notemodel.cpp
+++ b/src/models/notemodel.cpp
@@ -60,7 +60,6 @@ NoteModel::NoteModel(QObject *parent)
 QString NoteModel::orderByClause() const {
     QString order("order by " + global.getSortOrder());
     QLOG_DEBUG() << "Sort order: " << order;
-
     return order;
 }
 

--- a/src/nixnote.cpp
+++ b/src/nixnote.cpp
@@ -3730,3 +3730,15 @@ void NixNote::showAnnouncementMessage() {
     //         "\n\n"
     //         "Sorry for additional inconvenience..");
 }
+
+
+void NixNote::resetNoteTableSortColumn() {
+    // Sort the notetableview by a non-existing column, to reset the sort column.
+    // This function is only called after the sort menu's item is clicked.
+    // Without calling this function, the sort will not work, because the
+    // notetableview is set to sortable(setSortingEnabled(true)), and within
+    // setSortingEnabled(), a normal sortBycolumn() is called, which will lock
+    // the items order.
+    int sortColumn = noteTableView->horizontalHeader()->count();
+    noteTableView->sortByColumn(sortColumn);
+}

--- a/src/nixnote.h
+++ b/src/nixnote.h
@@ -203,7 +203,8 @@ public:
     bool event(QEvent *event);
     LineEdit *searchText;
     NTabWidget *tabWindow;
-void showAnnouncementMessage();
+    void showAnnouncementMessage();
+    void resetNoteTableSortColumn();
 
 private slots:
     void onNetworkManagerFinished(QNetworkReply *reply);


### PR DESCRIPTION
In pr 187, I restored the sort by manual clicking, but broke the sort from menu unexpectedly. I have made two ways of sorting co-exist.