### PR TITLE
Fix the issue: regression since v2.1.9: nixnote2 no longer exiting cleanly (terminated by SIGABRT) #208

### DIFF
--- a/src/gui/nbrowserwindow.cpp
+++ b/src/gui/nbrowserwindow.cpp
@@ -308,6 +308,7 @@ NBrowserWindow::NBrowserWindow(QWidget *parent) :
 NBrowserWindow::~NBrowserWindow() {
     browserThread->quit();
     while (!browserRunner->isIdle);
+    while (!browserThread->isFinished());
 
     delete browserThread;
     delete browserRunner;

--- a/src/gui/nmainmenubar.cpp
+++ b/src/gui/nmainmenubar.cpp
@@ -645,7 +645,7 @@ void NMainMenuBar::onSortMenuTriggered() {
     QString data = pAction->data().toString();
     QLOG_DEBUG() << "sort action data= " << data;
     global.setSortOrder(data);
-    parent->resetNoteTableSortColumn();
+    parent->unsortNoteTable();
 
     // refresh result set
     parent->updateSelectionCriteria(false);

--- a/src/nixnote.cpp
+++ b/src/nixnote.cpp
@@ -3729,13 +3729,8 @@ void NixNote::showAnnouncementMessage() {
 }
 
 
-void NixNote::resetNoteTableSortColumn() {
-    // Sort the notetableview by a non-existing column, to reset the sort column.
-    // This function is only called after the sort menu's item is clicked.
-    // Without calling this function, the sort will not work, because the
-    // notetableview is set to sortable(setSortingEnabled(true)), and within
-    // setSortingEnabled(), a normal sortBycolumn() is called, which will lock
-    // the items order.
+void NixNote::unsortNoteTable() {
+    // Sort the notetableview by a non-existing column
     int sortColumn = noteTableView->horizontalHeader()->count();
     noteTableView->sortByColumn(sortColumn);
 }

--- a/src/nixnote.cpp
+++ b/src/nixnote.cpp
@@ -243,6 +243,7 @@ NixNote::NixNote(QWidget *parent) : QMainWindow(parent) {
 
 // Destructor to call when all done
 NixNote::~NixNote() {
+    QLOG_DEBUG() << "~NixNote: Closing threads";
     syncThread.quit();
     indexThread.quit();
     counterThread.quit();
@@ -1298,10 +1299,6 @@ void NixNote::saveOnExit() {
     saveNoteColumnWidths();
     saveNoteColumnPositions();
     noteTableView->saveColumnsVisible();
-
-    QLOG_DEBUG() << "saveOnExit: Closing threads";
-    indexThread.quit();
-    counterThread.quit();
 
     QLOG_DEBUG() << "Exiting saveOnExit()";
 }

--- a/src/nixnote.h
+++ b/src/nixnote.h
@@ -204,7 +204,7 @@ public:
     LineEdit *searchText;
     NTabWidget *tabWindow;
     void showAnnouncementMessage();
-    void resetNoteTableSortColumn();
+    void unsortNoteTable();
 
 private slots:
     void onNetworkManagerFinished(QNetworkReply *reply);


### PR DESCRIPTION
Fix issue 208 and rename NixNote::resetNoteTableSortColumn to NixNote::unsortNoteTable.