### PR TITLE
Update to point to the new docker file for to tell build dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ Basic familiarity with docker is helpful.
 More info in: [DOCKER README](docs/DOCKER-README.md)   
 
 ### Linux - manual build
-* Install development dependencies - look in content of [this docker file](development/docker/Dockerfile.ubuntu_xenial)
+* Install development dependencies - look in content of [this docker file](development/docker/Dockerfile.ubuntu_focal)
   or [.travis.yml](https://github.com/robert7/nixnote2/blob/master/.travis.yml)
   or [debian/control](https://github.com/robert7/nixnote2/blob/master/debian/control)
   to see example, what is needed for Ubuntu. If you use another distribution/version,


### PR DESCRIPTION
Fixup for commit 03837e6 "Issue #171: switch docker build to Ubuntu focal and using system browser for OAuth"

Sync the README to point to the new ubuntu focal Dockerfile. The old xenial one is no more.

Closes #211.