### PR TITLE
Fix issue 222: API Issues with initial sync (RateLimitExceeded)

### DIFF
--- a/nixnote2.pro
+++ b/nixnote2.pro
@@ -1,4 +1,4 @@
-QT += core gui widgets printsupport webkit webkitwidgets sql network xml dbus qml
+QT += core gui widgets printsupport webkit webkitwidgets sql network xml dbus qml concurrent
 
 DEFINES += QT_DISABLE_DEPRECATED_BEFORE=0
 unix {

--- a/src/communication/communicationmanager.cpp
+++ b/src/communication/communicationmanager.cpp
@@ -51,6 +51,8 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #include <curl/easy.h>
 #endif // End windows check
 
+#include <qtconcurrentmap.h>
+
 #include "src/utilities/debugtool.h"
 
 
@@ -781,6 +783,13 @@ bool CommunicationManager::getNoteVersion(Note &note, QString guid, qint32 usn, 
 }
 
 
+Note CommunicationManager::downloadNote(const Note &n) {
+    QLOG_DEBUG() << "downloadNote guid=" << n.guid;
+    Note tmp = n;
+    this->getNote(tmp, n.guid, true, true, true);
+    return tmp;
+}
+
 // Get a prior version of a notebook
 bool CommunicationManager::getNote(Note &note, QString guid, bool withResource, bool withResourceRecognition,
                                    bool withResourceAlternateData) {
@@ -1009,12 +1018,30 @@ void CommunicationManager::processSyncChunk(SyncChunk &chunk, QString token) {
     if (chunk.notes.isSet())
         notes = chunk.notes;
     auto requestContext = newRequestContext(token, requestTimeout);
+
+    QList<Note> downloadedNotes;
+    downloadedNotes.clear();
+
+    const int THREAD_NUMBER = 5;
+    for (int i = 0; i < notes.size(); i += THREAD_NUMBER) {
+        QList<Note> tmpNotes;
+        tmpNotes.clear();
+        for (int j = i; j < i + THREAD_NUMBER && j < notes.size(); j++) {
+            tmpNotes.append(notes[j]);
+            QLOG_TRACE() << "Fetching chunk item: " << j << ": " << notes[j].title;
+        }
+        downloadedNotes.append(QtConcurrent::blockingMapped<QList<Note> >(tmpNotes,
+                    std::bind(&CommunicationManager::downloadNote, this, std::placeholders::_1)));
+        QLOG_TRACE() << "A set of notes Retrieved";
+    }
+
     for (int i = 0; i < notes.size(); i++) {
-        QLOG_TRACE() << "Fetching chunk item: " << i << ": " << notes[i].title;
+        //QLOG_TRACE() << "Fetching chunk item: " << i << ": " << notes[i].title;
         Note n = notes[i];
         noteList.insert(n.guid, "");
-        n = noteStore->getNote(notes[i].guid, true, true, true, true, requestContext);
-        QLOG_TRACE() << "Note Retrieved";
+        //n = noteStore->getNote(notes[i].guid, true, true, true, true, requestContext);
+        n = downloadedNotes[i];
+        //QLOG_TRACE() << "Note Retrieved";
 
         // Load up the tag names because Evernote doesn't give them.
         QList<QString> tagNames;

--- a/src/communication/communicationmanager.cpp
+++ b/src/communication/communicationmanager.cpp
@@ -54,6 +54,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #include "src/utilities/debugtool.h"
 
 
+
 extern Global global;
 
 // set Evernote http timeout to 4 minutes
@@ -307,6 +308,9 @@ CommunicationManager::getSyncChunk(SyncChunk &chunk, int start, int chunkSize, i
         return false;
     } catch (EDAMNotFoundException &e) {
         handleEDAMNotFoundException(e);
+        return false;
+    } catch (std::exception &e) { // connection closed by the server
+        reportError(CommunicationError::StdException, 16, e.what());
         return false;
     }
     return true;

--- a/src/communication/communicationmanager.h
+++ b/src/communication/communicationmanager.h
@@ -122,6 +122,7 @@ public:
     bool authenticateToLinkedNotebookShard(LinkedNotebook &book);    // Authenticate to a linked notebook account owner shard
     bool getUserInfo(User &user);                              // Get user information
     bool getNote(Note &n, QString guid, bool wthResource, bool withRecognition, bool withResource);
+    Note downloadNote(const Note &n);
     QList< QPair<QString, QImage*>* > *inkNoteList;            // List to store inknotes downloaded from account.
     QList< QPair<QString, QImage*>* > *thumbnailList;          // List to store thumbnails from account (not used)
     QHash<QString,QString> *tagGuidMap;                        // Temporary hashmap used to store tags.  Keeps from repetitive DB lookups filling in tag names

--- a/src/dialog/preferences/syncpreferences.cpp
+++ b/src/dialog/preferences/syncpreferences.cpp
@@ -47,6 +47,7 @@ SyncPreferences::SyncPreferences(QWidget *parent) :
     enableSyncNotifications = new QCheckBox(tr("Enable sync notifications"), this);
     showGoodSyncMessagesInTray = new QCheckBox(tr("Show successful syncs"), this);
     apiRateRestart = new QCheckBox(tr("Restart sync on API limit (experimental)"), this);
+    connectionClosedRestart = new QCheckBox(tr("Restart sync on connection closed (experimental)"), this);
 
     enableProxy = new QCheckBox(tr("Enable Proxy*"), this);
     enableSocks5 = new QCheckBox(tr("Enable Socks5"),this);
@@ -81,6 +82,7 @@ SyncPreferences::SyncPreferences(QWidget *parent) :
     mainLayout->addWidget(syncAutomatically,3,0);
     mainLayout->addWidget(syncInterval, 3,1);
     mainLayout->addWidget(apiRateRestart, 4,0);
+    mainLayout->addWidget(connectionClosedRestart, 4,1);
 
     mainLayout->addWidget(enableProxy,5,0);
     mainLayout->addWidget(enableSocks5,5,1);
@@ -105,6 +107,8 @@ SyncPreferences::SyncPreferences(QWidget *parent) :
     enableSyncNotifications->setChecked(global.settings->value("enableNotification", true).toBool());
     showGoodSyncMessagesInTray->setChecked(global.showGoodSyncMessagesInTray);
     apiRateRestart->setChecked(global.settings->value("apiRateLimitAutoRestart", true).toBool());
+    connectionClosedRestart->setChecked(global.settings->value("connectionClosedAutoRestart", false).toBool());
+
     global.settings->endGroup();
     global.showGoodSyncMessagesInTray = showGoodSyncMessagesInTray->isChecked();
 
@@ -159,6 +163,7 @@ void SyncPreferences::saveValues() {
     global.settings->setValue("syncInterval", getSyncInterval());
     global.settings->setValue("showGoodSyncMessagesInTray", showGoodSyncMessagesInTray ->isChecked());
     global.settings->setValue("apiRateLimitAutoRestart", apiRateRestart ->isChecked());
+    global.settings->setValue("connectionClosedAutoRestart", connectionClosedRestart->isChecked());
     global.settings->endGroup();
 
     global.showGoodSyncMessagesInTray = showGoodSyncMessagesInTray->isChecked();

--- a/src/dialog/preferences/syncpreferences.h
+++ b/src/dialog/preferences/syncpreferences.h
@@ -37,6 +37,7 @@ private:
     QCheckBox *syncAutomatically;
     QCheckBox *syncOnShutdown;
     QCheckBox *apiRateRestart;
+    QCheckBox *connectionClosedRestart;
     QCheckBox *popupOnSyncError;
 
     QCheckBox *enableProxy;

--- a/src/nixnote.cpp
+++ b/src/nixnote.cpp
@@ -1584,15 +1584,33 @@ void NixNote::syncButtonReset() {
     syncButtonTimer.stop();
     syncButton->setIcon(syncIcons[0]);
 
+    global.settings->beginGroup(INI_GROUP_SYNC);
+    bool apiRateLimitAutoRestart =
+        global.settings->value("apiRateLimitAutoRestart", false).toBool();
+    bool connectionClosedAutoRestart =
+        global.settings->value("connectionClosedAutoRestart", false).toBool();
+    global.settings->endGroup();
+
     // If we had an API rate limit exceeded, restart at the top of the hour.
-    if (syncRunner.apiRateLimitExceeded) {
-        global.settings->beginGroup(INI_GROUP_SYNC);
-        bool restart = global.settings->value("apiRateLimitAutoRestart", false).toBool();
-        global.settings->endGroup();
-        if (restart) {
-            QTimer::singleShot(60 * 1000 * (syncRunner.minutesToNextSync + 1), this, SLOT(synchronize()));
-        }
+    if (apiRateLimitAutoRestart && syncRunner.apiRateLimitExceeded) {
+        QTimer::singleShot(60 * 1000 * (syncRunner.minutesToNextSync + 1),
+                this, SLOT(synchronize()));
+        return;
     }
+
+    if (connectionClosedAutoRestart && syncRunner.connectionClosed) {
+        synchronize();
+    }
+
+//// If we had an API rate limit exceeded, restart at the top of the hour.
+//    if (syncRunner.apiRateLimitExceeded) {
+//        global.settings->beginGroup(INI_GROUP_SYNC);
+//        bool restart = global.settings->value("apiRateLimitAutoRestart", false).toBool();
+//        global.settings->endGroup();
+//        if (restart) {
+//            QTimer::singleShot(60 * 1000 * (syncRunner.minutesToNextSync + 1), this, SLOT(synchronize()));
+//        }
+//    }
 }
 
 

--- a/src/threads/syncrunner.cpp
+++ b/src/threads/syncrunner.cpp
@@ -85,7 +85,6 @@ void SyncRunner::synchronize() {
 
     if (!comm->enConnect()) {
         QLOG_DEBUG() << "synchronize: connect failed";
-
         this->communicationErrorHandler();
         error = true;
         emit syncComplete();
@@ -265,7 +264,7 @@ bool SyncRunner::syncRemoteToLocal(qint32 updateCount) {
 
     comm->loadTagGuidMap();
     more = true;
-    chunkSize = 200;
+    chunkSize = 50;
     updateSequenceNumber = startingSequenceNumber;
     UserTable userTable(db);
 
@@ -278,6 +277,9 @@ bool SyncRunner::syncRemoteToLocal(qint32 updateCount) {
             QLOG_ERROR() << "Error retrieving chunk";
             error = true;
             this->communicationErrorHandler();
+            if (comm->getLastErrorType() == CommunicationError::StdException) {
+                emit syncComplete();
+            }
             QLOG_TRACE_OUT();
             return false;
         }

--- a/src/threads/syncrunner.cpp
+++ b/src/threads/syncrunner.cpp
@@ -44,6 +44,7 @@ SyncRunner::SyncRunner() {
     minutesToNextSync = 0;
     error = false;
     updateUserDataOnNextSync = false;
+    connectionClosed = false;
 }
 
 SyncRunner::~SyncRunner() {
@@ -59,6 +60,7 @@ void SyncRunner::synchronize() {
         consumerKey = "";
         secret = "";
         apiRateLimitExceeded = false;
+        connectionClosed = false;
 
         // Setup the user agent
         userAgent = NN_APP_CLIENT_NAME;
@@ -1222,7 +1224,9 @@ qint32 SyncRunner::uploadPersonalNotes() {
 void SyncRunner::communicationErrorHandler() {
     CommunicationError::CommunicationErrorType type = comm->getLastErrorType();
 
-    if (type == CommunicationError::None) {
+    if (type == CommunicationError::None ||
+            type == CommunicationError::StdException) {
+        connectionClosed = true;
         return;
     }
 

--- a/src/threads/syncrunner.h
+++ b/src/threads/syncrunner.h
@@ -115,6 +115,7 @@ public:
 
     bool apiRateLimitExceeded;
     qint32 minutesToNextSync;                    // After "API rate limit exceeded" how long should we wait to attempt sync notes (continue syncing large lists of notes - for example when user setup nixnote for first time)
+    bool connectionClosed;
 
 
 signals:


### PR DESCRIPTION
Synchronize the notes with five threads, it used single thread before. And catch the std::exception thrown from processSyncChunk() and deal with it properly to make the sync button stop when the connection is closed(by the server or by other network exceptions).