### PR TITLE
Fix issue 222: crash with 'qevercloud::EverCloudException' and incomplete note content

### DIFF
--- a/src/communication/communicationmanager.h
+++ b/src/communication/communicationmanager.h
@@ -40,6 +40,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #include <QObject>
 #include <QNetworkAccessManager>
 #include <QSqlDatabase>
+#include <QMutex>
 
 #include "src/qevercloud/QEverCloud/headers/QEverCloud.h"
 using namespace qevercloud;
@@ -103,6 +104,8 @@ private:
                      const QString &internalMessage = QString());
 
     CommunicationError error;
+    EverCloudException *threadException;
+    QMutex mutex;
 
 public:
 


### PR DESCRIPTION
Catch EverCloudException thrown from getNote() within CommunicationManager::downloadNote(), and process it in the main thread.
